### PR TITLE
Missing word and removing extra closing tags

### DIFF
--- a/hmda/console/index.html
+++ b/hmda/console/index.html
@@ -117,7 +117,7 @@
 
 <h5 id='ready_to_dive_deeper'>Ready to dive deeper?</h5>
 
-<p>See all functions and enumerations in our <a href="../queries.html">Query language</a>, or look up all the variables and values found in LAR data at <a href="../fields.html">Field reference</a>. To learn more about what LAR data is and how it is collected, <a href="http://consumerfinance.gov/hmda/learn-more">HMDA</a> at <a href="http://consumerfinance.gov/">CFPB</a>. 
+<p>See all functions and enumerations in our <a href="../queries.html">Query language</a>, or look up all the variables and values found in LAR data at <a href="../fields.html">Field reference</a>. To learn more about what LAR data is and how it is collected, visit <a href="http://consumerfinance.gov/hmda/learn-more">HMDA</a> at <a href="http://consumerfinance.gov/">CFPB</a>. 
     </section>
 
     </div>
@@ -158,11 +158,4 @@
   <script src="../static/js/docs.min.js"></script>
   <script type="text/javascript" src="../static/js/expandables.js"></script>
 </body>
-</html>
-
-
-
-
-</body>
-
 </html>


### PR DESCRIPTION
We were missing a word at the end when telling people to visit the HMDA page. Also, there were two sets of closing tags for /body and /html
