### PR TITLE
hiding console operations that freeze browser

### DIFF
--- a/hmda/console/css/screen.css
+++ b/hmda/console/css/screen.css
@@ -679,9 +679,19 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     float: none;
     clear: both;
     overflow: hidden;
-    display: block;
+    /*display: block;*/
     margin: 0 0 10px;
     padding: 0;
+}
+
+
+/* hiding operations that freeze browser */
+#data_getDataset_get_1.operation.get {
+    display: none;
+}
+
+#hmda_getDatasetHmda_get_0.operation.get {
+    display: none;
 }
 
 body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading {
@@ -861,6 +871,8 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     padding: 0.125em 0.250em;
 
 }
+
+
 
 /* THESE ARE FOR POST CALLS ONLY 
 body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post {


### PR DESCRIPTION
Making some usability fixes to the docs thanks to feedback received from a session at 18f last week. Hiding /data/{dataset} and /data/hmda from the console for now.
