### PR TITLE
Add '-s' in Drakefile to use symbolic link

### DIFF
--- a/resources/datasets/hmda/Drakefile
+++ b/resources/datasets/hmda/Drakefile
@@ -52,7 +52,7 @@ convert_ts_to_csv() [python]
         csvout.writerow(row)
 
 link()
-  ln -f $INPUT $OUTPUT
+  ln -f -s $INPUT $OUTPUT
 
 gaz_counties.zip <- [-timecheck]
   curl http://www.census.gov/geo/maps-data/data/docs/gazetteer/Gaz_counties_national.zip > $OUTPUT


### PR DESCRIPTION
Some systems struggle when using hard links.  Notably, hard links don't work in shared directories created by Virtualbox.  Using the symbolic link option `-s` works around this limitation.
