### PR TITLE
Add county_code to dimensions for census_tracts derived slice

### DIFF
--- a/resources/datasets/hmda/definition.json
+++ b/resources/datasets/hmda/definition.json
@@ -703,6 +703,7 @@
       "slice": "hmda_lar",
       "dimensions": [
         "state_code",
+        "county_code",
         "msamd",
         "census_tract_number"
       ],


### PR DESCRIPTION
Problem: Census tracts are not unique by state, they are actually unique by county.

For example, the "0001.00" census tract appears in five different counties in Arizona, and these counties are not even close to each other.

Adding county_code to the list of dimensions (currently state, msamd, and census tract number) will insure that the census tracts are accurately aggregated.
