### PR TITLE
Add 2013 MSAMD mappings

### DIFF
--- a/resources/datasets/hmda/code_sheets/msamd.csv
+++ b/resources/datasets/hmda/code_sheets/msamd.csv
@@ -2351,3 +2351,396 @@ year,code,name
 2010,49740,Yuma - AZ
 2011,49740,Yuma - AZ
 2012,49740,Yuma - AZ
+2013,10180,Abilene - TX
+2013,10380,"Aguadilla, Isabela, San Sebastian - PR"
+2013,10420,Akron - OH
+2013,10500,Albany - GA
+2013,10580,"Albany, Schenectady, Troy - NY"
+2013,10740,Albuquerque - NM
+2013,10780,Alexandria - LA
+2013,10900,"Allentown, Bethlehem, Easton - PA, NJ"
+2013,11020,Altoona - PA
+2013,11100,Amarillo - TX
+2013,11180,Ames - IA
+2013,11260,Anchorage - AK
+2013,11300,Anderson - IN
+2013,11340,Anderson - SC
+2013,11460,Ann Arbor - MI
+2013,11500,"Anniston, Oxford - AL"
+2013,11540,Appleton - WI
+2013,11700,Asheville - NC
+2013,12020,"Athens, Clarke County - GA"
+2013,12060,"Atlanta, Sandy Springs, Marietta - GA"
+2013,12100,"Atlantic City, Hammonton - NJ"
+2013,12220,"Auburn, Opelika - AL"
+2013,12260,"Augusta, Richmond County - GA, SC"
+2013,12420,"Austin, Round Rock, San Marcos - TX"
+2013,12540,"Bakersfield, Delano - CA"
+2013,12580,"Baltimore, Towson - MD"
+2013,12620,Bangor - ME
+2013,12700,Barnstable Town - MA
+2013,12940,Baton Rouge - LA
+2013,12980,Battle Creek - MI
+2013,13020,Bay City - MI
+2013,13140,"Beaumont, Port Arthur - TX"
+2013,13380,Bellingham - WA
+2013,13460,Bend - OR
+2013,13644,"Bethesda, Rockville, Frederick - MD"
+2013,13740,Billings - MT
+2013,13780,Binghamton - NY
+2013,13820,"Birmingham, Hoover - AL"
+2013,13900,Bismarck - ND
+2013,13980,"Blacksburg, Christiansburg, Radford - VA"
+2013,14020,Bloomington - IN
+2013,14060,"Bloomington, Normal - IL"
+2013,14260,"Boise City, Nampa - ID"
+2013,14484,"Boston, Quincy - MA"
+2013,14500,Boulder - CO
+2013,14540,Bowling Green - KY
+2013,14740,"Bremerton, Silverdale - WA"
+2013,14860,"Bridgeport, Stamford, Norwalk - CT"
+2013,15180,"Brownsville, Harlingen - TX"
+2013,15260,Brunswick - GA
+2013,15380,"Buffalo, Niagara Falls - NY"
+2013,15500,Burlington - NC
+2013,15540,"Burlington, South Burlington - VT"
+2013,15764,"Cambridge, Newton, Framingham - MA"
+2013,15804,Camden - NJ
+2013,15940,"Canton, Massillon - OH"
+2013,15980,"Cape Coral, Fort Myers - FL"
+2013,16020,"Cape Girardeau, Jackson - MO, IL"
+2013,16180,Carson City - NV
+2013,16220,Casper - WY
+2013,16300,Cedar Rapids - IA
+2013,16580,"Champaign, Urbana - IL"
+2013,16620,Charleston - WV
+2013,16700,"Charleston, North Charleston, Summerville - SC"
+2013,16740,"Charlotte, Gastonia, Rock Hill - NC, SC"
+2013,16820,Charlottesville - VA
+2013,16860,"Chattanooga - TN, GA"
+2013,16940,Cheyenne - WY
+2013,16974,"Chicago, Joliet, Naperville - IL"
+2013,17020,Chico - CA
+2013,17140,"Cincinnati, Middletown - OH, KY, IN"
+2013,17300,"Clarksville - TN, KY"
+2013,17420,Cleveland - TN
+2013,17460,"Cleveland, Elyria, Mentor - OH"
+2013,17660,Coeur D'Alene - ID
+2013,17780,"College Station, Bryan - TX"
+2013,17820,Colorado Springs - CO
+2013,17860,Columbia - MO
+2013,17900,Columbia - SC
+2013,17980,"Columbus - GA, AL"
+2013,18020,Columbus - IN
+2013,18140,Columbus - OH
+2013,18580,Corpus Christi - TX
+2013,18700,Corvallis - OR
+2013,18880,"Crestview, Fort Walton Beach, Destin - FL"
+2013,19060,"Cumberland - MD, WV"
+2013,19124,"Dallas, Plano, Irving - TX"
+2013,19140,Dalton - GA
+2013,19180,Danville - IL
+2013,19260,Danville - VA
+2013,19340,"Davenport, Moline, Rock Island - IA, IL"
+2013,19380,Dayton - OH
+2013,19460,Decatur - AL
+2013,19500,Decatur - IL
+2013,19660,"Deltona, Daytona Beach, Ormond Beach - FL"
+2013,19740,"Denver, Aurora, Broomfield - CO"
+2013,19780,"Des Moines, West Des Moines - IA"
+2013,19804,"Detroit, Livonia, Dearborn - MI"
+2013,20020,Dothan - AL
+2013,20100,Dover - DE
+2013,20220,Dubuque - IA
+2013,20260,"Duluth - MN, WI"
+2013,20500,"Durham, Chapel Hill - NC"
+2013,20740,Eau Claire - WI
+2013,20764,"Edison, New Brunswick - NJ"
+2013,20940,El Centro - CA
+2013,21060,Elizabethtown - KY
+2013,21140,"Elkhart, Goshen - IN"
+2013,21300,Elmira - NY
+2013,21340,El Paso - TX
+2013,21500,Erie - PA
+2013,21660,"Eugene, Springfield - OR"
+2013,21780,"Evansville - IN, KY"
+2013,21820,Fairbanks - AK
+2013,21940,Fajardo - PR
+2013,22020,"Fargo - ND, MN"
+2013,22140,Farmington - NM
+2013,22180,Fayetteville - NC
+2013,22220,"Fayetteville, Springdale, Rogers - AR, MO"
+2013,22380,Flagstaff - AZ
+2013,22420,Flint - MI
+2013,22500,Florence - SC
+2013,22520,"Florence, Muscle Shoals - AL"
+2013,22540,Fond du Lac - WI
+2013,22660,"Fort Collins, Loveland - CO"
+2013,22744,"Fort Lauderdale, Pompano Beach, Deerfield Beach - FL"
+2013,22900,"Fort Smith - AR, OK"
+2013,23060,Fort Wayne - IN
+2013,23104,"Fort Worth, Arlington - TX"
+2013,23420,Fresno - CA
+2013,23460,Gadsden - AL
+2013,23540,Gainesville - FL
+2013,23580,Gainesville - GA
+2013,23844,Gary - IN
+2013,24020,Glens Falls - NY
+2013,24140,Goldsboro - NC
+2013,24220,"Grand Forks - ND, MN"
+2013,24300,Grand Junction - CO
+2013,24340,"Grand Rapids, Wyoming - MI"
+2013,24500,Great Falls - MT
+2013,24540,Greeley - CO
+2013,24580,Green Bay - WI
+2013,24660,"Greensboro, High Point - NC"
+2013,24780,Greenville - NC
+2013,24860,"Greenville, Mauldin, Easley - SC"
+2013,25020,Guayama - PR
+2013,25060,"Gulfport, Biloxi - MS"
+2013,25180,"Hagerstown, Martinsburg - MD, WV"
+2013,25260,"Hanford, Corcoran - CA"
+2013,25420,"Harrisburg, Carlisle - PA"
+2013,25500,Harrisonburg - VA
+2013,25540,"Hartford, West Hartford, East Hartford - CT"
+2013,25620,Hattiesburg - MS
+2013,25860,"Hickory, Lenoir, Morganton - NC"
+2013,25980,"Hinesville, Fort Stewart - GA"
+2013,26100,"Holland, Grand Haven - MI"
+2013,26180,Honolulu - HI
+2013,26300,Hot Springs - AR
+2013,26380,"Houma, Bayou Cane, Thibodaux - LA"
+2013,26420,"Houston, Sugar Land, Baytown - TX"
+2013,26580,"Huntington, Ashland - WV, KY, OH"
+2013,26620,Huntsville - AL
+2013,26820,Idaho Falls - ID
+2013,26900,"Indianapolis, Carmel - IN"
+2013,26980,Iowa City - IA
+2013,27060,Ithaca - NY
+2013,27100,Jackson - MI
+2013,27140,Jackson - MS
+2013,27180,Jackson - TN
+2013,27260,Jacksonville - FL
+2013,27340,Jacksonville - NC
+2013,27500,Janesville - WI
+2013,27620,Jefferson City - MO
+2013,27740,Johnson City - TN
+2013,27780,Johnstown - PA
+2013,27860,Jonesboro - AR
+2013,27900,Joplin - MO
+2013,28020,"Kalamazoo, Portage - MI"
+2013,28100,"Kankakee, Bradley - IL"
+2013,28140,"Kansas City - MO, KS"
+2013,28420,"Kennewick, Pasco, Richland - WA"
+2013,28660,"Killeen, Temple, Fort Hood - TX"
+2013,28700,"Kingsport, Bristol, Bristol - TN, VA"
+2013,28740,Kingston - NY
+2013,28940,Knoxville - TN
+2013,29020,Kokomo - IN
+2013,29100,"La Crosse - WI, MN"
+2013,29140,Lafayette - IN
+2013,29180,Lafayette - LA
+2013,29340,Lake Charles - LA
+2013,29404,"Lake County, Kenosha County - IL, WI"
+2013,29420,"Lake Havasu City, Kingman - AZ"
+2013,29460,"Lakeland, Winter Haven - FL"
+2013,29540,Lancaster - PA
+2013,29620,"Lansing, East Lansing - MI"
+2013,29700,Laredo - TX
+2013,29740,Las Cruces - NM
+2013,29820,"Las Vegas, Paradise - NV"
+2013,29940,Lawrence - KS
+2013,30020,Lawton - OK
+2013,30140,Lebanon - PA
+2013,30300,"Lewiston - ID, WA"
+2013,30340,"Lewiston, Auburn - ME"
+2013,30460,"Lexington, Fayette - KY"
+2013,30620,Lima - OH
+2013,30700,Lincoln - NE
+2013,30780,"Little Rock, North Little Rock, Conway - AR"
+2013,30860,"Logan - UT, ID"
+2013,30980,Longview - TX
+2013,31020,Longview - WA
+2013,31084,"Los Angeles, Long Beach, Glendale - CA"
+2013,31140,"Louisville, Jefferson County - KY, IN"
+2013,31180,Lubbock - TX
+2013,31340,Lynchburg - VA
+2013,31420,Macon - GA
+2013,31460,"Madera, Chowchilla - CA"
+2013,31540,Madison - WI
+2013,31700,"Manchester, Nashua - NH"
+2013,31740,Manhattan - KS
+2013,31860,"Mankato, North Mankato - MN"
+2013,31900,Mansfield - OH
+2013,32420,Mayaguez - PR
+2013,32580,"McAllen, Edinburg, Mission - TX"
+2013,32780,Medford - OR
+2013,32820,"Memphis - TN, MS, AR"
+2013,32900,Merced - CA
+2013,33124,"Miami, Miami Beach, Kendall - FL"
+2013,33140,"Michigan City, La Porte - IN"
+2013,33260,Midland - TX
+2013,33340,"Milwaukee, Waukesha, West Allis - WI"
+2013,33460,"Minneapolis, St. Paul, Bloomington - MN, WI"
+2013,33540,Missoula - MT
+2013,33660,Mobile - AL
+2013,33700,Modesto - CA
+2013,33740,Monroe - LA
+2013,33780,Monroe - MI
+2013,33860,Montgomery - AL
+2013,34060,Morgantown - WV
+2013,34100,Morristown - TN
+2013,34580,"Mount Vernon, Anacortes - WA"
+2013,34620,Muncie - IN
+2013,34740,"Muskegon, Norton Shores - MI"
+2013,34820,"Myrtle Beach, North Myrtle Beach, Conway - SC"
+2013,34900,Napa - CA
+2013,34940,"Naples, Marco Island - FL"
+2013,34980,"Nashville, Davidson, Murfreesboro, Franklin - TN"
+2013,35004,"Nassau, Suffolk - NY"
+2013,35084,"Newark, Union - NJ, PA"
+2013,35300,"New Haven, Milford - CT"
+2013,35380,"New Orleans, Metairie, Kenner - LA"
+2013,35644,"New York, White Plains, Wayne - NY, NJ"
+2013,35660,"Niles, Benton Harbor - MI"
+2013,35840,"North Port, Bradenton, Sarasota - FL"
+2013,35980,"Norwich, New London - CT"
+2013,36084,"Oakland, Fremont, Hayward - CA"
+2013,36100,Ocala - FL
+2013,36140,Ocean City - NJ
+2013,36220,Odessa - TX
+2013,36260,"Ogden, Clearfield - UT"
+2013,36420,Oklahoma City - OK
+2013,36500,Olympia - WA
+2013,36540,"Omaha, Council Bluffs - NE, IA"
+2013,36740,"Orlando, Kissimmee, Sanford - FL"
+2013,36780,"Oshkosh, Neenah - WI"
+2013,36980,Owensboro - KY
+2013,37100,"Oxnard, Thousand Oaks, Ventura - CA"
+2013,37340,"Palm Bay, Melbourne, Titusville - FL"
+2013,37380,Palm Coast - FL
+2013,37460,"Panama City, Lynn Haven, Panama City Beach - FL"
+2013,37620,"Parkersburg, Marietta, Vienna - WV, OH"
+2013,37700,Pascagoula - MS
+2013,37764,Peabody - MA
+2013,37860,"Pensacola, Ferry Pass, Brent - FL"
+2013,37900,Peoria - IL
+2013,37964,Philadelphia - PA
+2013,38060,"Phoenix, Mesa, Glendale - AZ"
+2013,38220,Pine Bluff - AR
+2013,38300,Pittsburgh - PA
+2013,38340,Pittsfield - MA
+2013,38540,Pocatello - ID
+2013,38660,Ponce - PR
+2013,38860,"Portland, South Portland, Biddeford - ME"
+2013,38900,"Portland, Vancouver, Hillsboro - OR, WA"
+2013,38940,Port St. Lucie - FL
+2013,39100,"Poughkeepsie, Newburgh, Middletown - NY"
+2013,39140,Prescott - AZ
+2013,39300,"Providence, New Bedford, Fall River - RI, MA"
+2013,39340,"Provo, Orem - UT"
+2013,39380,Pueblo - CO
+2013,39460,Punta Gorda - FL
+2013,39540,Racine - WI
+2013,39580,"Raleigh, Cary - NC"
+2013,39660,Rapid City - SD
+2013,39740,Reading - PA
+2013,39820,Redding - CA
+2013,39900,"Reno, Sparks - NV"
+2013,40060,Richmond - VA
+2013,40140,"Riverside, San Bernardino, Ontario - CA"
+2013,40220,Roanoke - VA
+2013,40340,Rochester - MN
+2013,40380,Rochester - NY
+2013,40420,Rockford - IL
+2013,40484,"Rockingham County, Strafford County - NH"
+2013,40580,Rocky Mount - NC
+2013,40660,Rome - GA
+2013,40900,"Sacramento, Arden, Arcade, Roseville - CA"
+2013,40980,"Saginaw, Saginaw Township North - MI"
+2013,41060,St. Cloud - MN
+2013,41100,St. George - UT
+2013,41140,"St. Joseph - MO, KS"
+2013,41180,"St. Louis - MO, IL"
+2013,41420,Salem - OR
+2013,41500,Salinas - CA
+2013,41540,Salisbury - MD
+2013,41620,Salt Lake City - UT
+2013,41660,San Angelo - TX
+2013,41700,"San Antonio, New Braunfels - TX"
+2013,41740,"San Diego, Carlsbad, San Marcos - CA"
+2013,41780,Sandusky - OH
+2013,41884,"San Francisco, San Mateo, Redwood City - CA"
+2013,41900,"San German, Cabo Rojo - PR"
+2013,41940,"San Jose, Sunnyvale, Santa Clara - CA"
+2013,41980,"San Juan, Caguas, Guaynabo - PR"
+2013,42020,"San Luis Obispo, Paso Robles - CA"
+2013,42044,"Santa Ana, Anaheim, Irvine - CA"
+2013,42060,"Santa Barbara, Santa Maria, Goleta - CA"
+2013,42100,"Santa Cruz, Watsonville - CA"
+2013,42140,Santa Fe - NM
+2013,42220,"Santa Rosa, Petaluma - CA"
+2013,42340,Savannah - GA
+2013,42540,"Scranton, Wilkes, Barre - PA"
+2013,42644,"Seattle, Bellevue, Everett - WA"
+2013,42680,"Sebastian, Vero Beach - FL"
+2013,43100,Sheboygan - WI
+2013,43300,"Sherman, Denison - TX"
+2013,43340,"Shreveport, Bossier City - LA"
+2013,43580,"Sioux City - IA, NE, SD"
+2013,43620,Sioux Falls - SD
+2013,43780,"South Bend, Mishawaka - IN, MI"
+2013,43900,Spartanburg - SC
+2013,44060,Spokane - WA
+2013,44100,Springfield - IL
+2013,44140,Springfield - MA
+2013,44180,Springfield - MO
+2013,44220,Springfield - OH
+2013,44300,State College - PA
+2013,44600,"Steubenville, Weirton - OH, WV"
+2013,44700,Stockton - CA
+2013,44940,Sumter - SC
+2013,45060,Syracuse - NY
+2013,45104,Tacoma - WA
+2013,45220,Tallahassee - FL
+2013,45300,"Tampa, St. Petersburg, Clearwater - FL"
+2013,45460,Terre Haute - IN
+2013,45500,"Texarkana, TX - Texarkana, AR"
+2013,45780,Toledo - OH
+2013,45820,Topeka - KS
+2013,45940,"Trenton, Ewing - NJ"
+2013,46060,Tucson - AZ
+2013,46140,Tulsa - OK
+2013,46220,Tuscaloosa - AL
+2013,46340,Tyler - TX
+2013,46540,"Utica, Rome - NY"
+2013,46660,Valdosta - GA
+2013,46700,"Vallejo, Fairfield - CA"
+2013,47020,Victoria - TX
+2013,47220,"Vineland, Millville, Bridgeton - NJ"
+2013,47260,"Virginia Beach, Norfolk, Newport News - VA, NC"
+2013,47300,"Visalia, Porterville - CA"
+2013,47380,Waco - TX
+2013,47580,Warner Robins - GA
+2013,47644,"Warren, Troy, Farmington Hills - MI"
+2013,47894,"Washington, Arlington, Alexandria - DC, VA, MD, WV"
+2013,47940,"Waterloo, Cedar Falls - IA"
+2013,48140,Wausau - WI
+2013,48300,"Wenatchee, East Wenatchee - WA"
+2013,48424,"West Palm Beach, Boca Raton, Boynton Beach - FL"
+2013,48540,"Wheeling - WV, OH"
+2013,48620,Wichita - KS
+2013,48660,Wichita Falls - TX
+2013,48700,Williamsport - PA
+2013,48864,"Wilmington - DE, MD, NJ"
+2013,48900,Wilmington - NC
+2013,49020,"Winchester - VA, WV"
+2013,49180,"Winston, Salem - NC"
+2013,49340,Worcester - MA
+2013,49420,Yakima - WA
+2013,49500,Yauco - PR
+2013,49620,"York, Hanover - PA"
+2013,49660,"Youngstown, Warren, Boardman - OH, PA"
+2013,49700,Yuba City - CA
+2013,49740,Yuma - AZ
+2013,99999,NA (Outside of MSA/MD)

--- a/resources/datasets/hmda/code_sheets/msamd.csv
+++ b/resources/datasets/hmda/code_sheets/msamd.csv
@@ -5,276 +5,322 @@ year,code,name
 2010,10180,Abilene - TX
 2011,10180,Abilene - TX
 2012,10180,Abilene - TX
+2013,10180,Abilene - TX
 2007,10380,"Aguadilla, Isabela, San Sebastian - PR"
 2008,10380,"Aguadilla, Isabela, San Sebastian - PR"
 2009,10380,"Aguadilla, Isabela, San Sebastian - PR"
 2010,10380,"Aguadilla, Isabela, San Sebastian - PR"
 2011,10380,"Aguadilla, Isabela, San Sebastian - PR"
 2012,10380,"Aguadilla, Isabela, San Sebastian - PR"
+2013,10380,"Aguadilla, Isabela, San Sebastian - PR"
 2007,10420,Akron - OH
 2008,10420,Akron - OH
 2009,10420,Akron - OH
 2010,10420,Akron - OH
 2011,10420,Akron - OH
 2012,10420,Akron - OH
+2013,10420,Akron - OH
 2007,10500,Albany - GA
 2008,10500,Albany - GA
 2009,10500,Albany - GA
 2010,10500,Albany - GA
 2011,10500,Albany - GA
 2012,10500,Albany - GA
+2013,10500,Albany - GA
 2007,10580,"Albany, Schenectady, Troy - NY"
 2008,10580,"Albany, Schenectady, Troy - NY"
 2009,10580,"Albany, Schenectady, Troy - NY"
 2010,10580,"Albany, Schenectady, Troy - NY"
 2011,10580,"Albany, Schenectady, Troy - NY"
 2012,10580,"Albany, Schenectady, Troy - NY"
+2013,10580,"Albany, Schenectady, Troy - NY"
 2007,10740,Albuquerque - NM
 2008,10740,Albuquerque - NM
 2009,10740,Albuquerque - NM
 2010,10740,Albuquerque - NM
 2011,10740,Albuquerque - NM
 2012,10740,Albuquerque - NM
+2013,10740,Albuquerque - NM
 2007,10780,Alexandria - LA
 2008,10780,Alexandria - LA
 2009,10780,Alexandria - LA
 2010,10780,Alexandria - LA
 2011,10780,Alexandria - LA
 2012,10780,Alexandria - LA
+2013,10780,Alexandria - LA
 2007,10900,"Allentown, Bethlehem, Easton - PA, NJ"
 2008,10900,"Allentown, Bethlehem, Easton - PA, NJ"
 2009,10900,"Allentown, Bethlehem, Easton - PA, NJ"
 2010,10900,"Allentown, Bethlehem, Easton - PA, NJ"
 2011,10900,"Allentown, Bethlehem, Easton - PA, NJ"
 2012,10900,"Allentown, Bethlehem, Easton - PA, NJ"
+2013,10900,"Allentown, Bethlehem, Easton - PA, NJ"
 2007,11020,Altoona - PA
 2008,11020,Altoona - PA
 2009,11020,Altoona - PA
 2010,11020,Altoona - PA
 2011,11020,Altoona - PA
 2012,11020,Altoona - PA
+2013,11020,Altoona - PA
 2007,11100,Amarillo - TX
 2008,11100,Amarillo - TX
 2009,11100,Amarillo - TX
 2010,11100,Amarillo - TX
 2011,11100,Amarillo - TX
 2012,11100,Amarillo - TX
+2013,11100,Amarillo - TX
 2007,11180,Ames - IA
 2008,11180,Ames - IA
 2009,11180,Ames - IA
 2010,11180,Ames - IA
 2011,11180,Ames - IA
 2012,11180,Ames - IA
+2013,11180,Ames - IA
 2007,11260,Anchorage - AK
 2008,11260,Anchorage - AK
 2009,11260,Anchorage - AK
 2010,11260,Anchorage - AK
 2011,11260,Anchorage - AK
 2012,11260,Anchorage - AK
+2013,11260,Anchorage - AK
 2007,11300,Anderson - IN
 2008,11300,Anderson - IN
 2009,11300,Anderson - IN
 2010,11300,Anderson - IN
 2011,11300,Anderson - IN
 2012,11300,Anderson - IN
+2013,11300,Anderson - IN
 2007,11340,Anderson - SC
 2008,11340,Anderson - SC
 2009,11340,Anderson - SC
 2010,11340,Anderson - SC
 2011,11340,Anderson - SC
 2012,11340,Anderson - SC
+2013,11340,Anderson - SC
 2007,11460,Ann Arbor - MI
 2008,11460,Ann Arbor - MI
 2009,11460,Ann Arbor - MI
 2010,11460,Ann Arbor - MI
 2011,11460,Ann Arbor - MI
 2012,11460,Ann Arbor - MI
+2013,11460,Ann Arbor - MI
 2007,11500,"Anniston, Oxford - AL"
 2008,11500,"Anniston, Oxford - AL"
 2009,11500,"Anniston, Oxford - AL"
 2010,11500,"Anniston, Oxford - AL"
 2011,11500,"Anniston, Oxford - AL"
 2012,11500,"Anniston, Oxford - AL"
+2013,11500,"Anniston, Oxford - AL"
 2007,11540,Appleton - WI
 2008,11540,Appleton - WI
 2009,11540,Appleton - WI
 2010,11540,Appleton - WI
 2011,11540,Appleton - WI
 2012,11540,Appleton - WI
+2013,11540,Appleton - WI
 2007,11700,Asheville - NC
 2008,11700,Asheville - NC
 2009,11700,Asheville - NC
 2010,11700,Asheville - NC
 2011,11700,Asheville - NC
 2012,11700,Asheville - NC
+2013,11700,Asheville - NC
 2007,12020,"Athens, Clarke County - GA"
 2008,12020,"Athens, Clarke County - GA"
 2009,12020,"Athens, Clarke County - GA"
 2010,12020,"Athens, Clarke County - GA"
 2011,12020,"Athens, Clarke County - GA"
 2012,12020,"Athens, Clarke County - GA"
+2013,12020,"Athens, Clarke County - GA"
 2007,12060,"Atlanta, Sandy Springs, Marietta - GA"
 2008,12060,"Atlanta, Sandy Springs, Marietta - GA"
 2009,12060,"Atlanta, Sandy Springs, Marietta - GA"
 2010,12060,"Atlanta, Sandy Springs, Marietta - GA"
 2011,12060,"Atlanta, Sandy Springs, Marietta - GA"
 2012,12060,"Atlanta, Sandy Springs, Marietta - GA"
+2013,12060,"Atlanta, Sandy Springs, Marietta - GA"
 2007,12100,Atlantic City - NJ
 2008,12100,"Atlantic City, Hammonton - NJ"
 2009,12100,"Atlantic City, Hammonton - NJ"
 2010,12100,"Atlantic City, Hammonton - NJ"
 2011,12100,"Atlantic City, Hammonton - NJ"
 2012,12100,"Atlantic City, Hammonton - NJ"
+2013,12100,"Atlantic City, Hammonton - NJ"
 2007,12220,"Auburn, Opelika - AL"
 2008,12220,"Auburn, Opelika - AL"
 2009,12220,"Auburn, Opelika - AL"
 2010,12220,"Auburn, Opelika - AL"
 2011,12220,"Auburn, Opelika - AL"
 2012,12220,"Auburn, Opelika - AL"
+2013,12220,"Auburn, Opelika - AL"
 2007,12260,"Augusta, Richmond County - GA, SC"
 2008,12260,"Augusta, Richmond County - GA, SC"
 2009,12260,"Augusta, Richmond County - GA, SC"
 2010,12260,"Augusta, Richmond County - GA, SC"
 2011,12260,"Augusta, Richmond County - GA, SC"
 2012,12260,"Augusta, Richmond County - GA, SC"
+2013,12260,"Augusta, Richmond County - GA, SC"
 2007,12420,"Austin, Round Rock - TX"
 2008,12420,"Austin, Round Rock - TX"
 2009,12420,"Austin, Round Rock - TX"
 2010,12420,"Austin, Round Rock, San Marcos - TX"
 2011,12420,"Austin, Round Rock, San Marcos - TX"
 2012,12420,"Austin, Round Rock, San Marcos - TX"
+2013,12420,"Austin, Round Rock, San Marcos - TX"
 2007,12540,Bakersfield - CA
 2008,12540,Bakersfield - CA
 2009,12540,Bakersfield - CA
 2010,12540,"Bakersfield, Delano - CA"
 2011,12540,"Bakersfield, Delano - CA"
 2012,12540,"Bakersfield, Delano - CA"
+2013,12540,"Bakersfield, Delano - CA"
 2007,12580,"Baltimore, Towson - MD"
 2008,12580,"Baltimore, Towson - MD"
 2009,12580,"Baltimore, Towson - MD"
 2010,12580,"Baltimore, Towson - MD"
 2011,12580,"Baltimore, Towson - MD"
 2012,12580,"Baltimore, Towson - MD"
+2013,12580,"Baltimore, Towson - MD"
 2007,12620,Bangor - ME
 2008,12620,Bangor - ME
 2009,12620,Bangor - ME
 2010,12620,Bangor - ME
 2011,12620,Bangor - ME
 2012,12620,Bangor - ME
+2013,12620,Bangor - ME
 2007,12700,Barnstable Town - MA
 2008,12700,Barnstable Town - MA
 2009,12700,Barnstable Town - MA
 2010,12700,Barnstable Town - MA
 2011,12700,Barnstable Town - MA
 2012,12700,Barnstable Town - MA
+2013,12700,Barnstable Town - MA
 2007,12940,Baton Rouge - LA
 2008,12940,Baton Rouge - LA
 2009,12940,Baton Rouge - LA
 2010,12940,Baton Rouge - LA
 2011,12940,Baton Rouge - LA
 2012,12940,Baton Rouge - LA
+2013,12940,Baton Rouge - LA
 2007,12980,Battle Creek - MI
 2008,12980,Battle Creek - MI
 2009,12980,Battle Creek - MI
 2010,12980,Battle Creek - MI
 2011,12980,Battle Creek - MI
 2012,12980,Battle Creek - MI
+2013,12980,Battle Creek - MI
 2007,13020,Bay City - MI
 2008,13020,Bay City - MI
 2009,13020,Bay City - MI
 2010,13020,Bay City - MI
 2011,13020,Bay City - MI
 2012,13020,Bay City - MI
+2013,13020,Bay City - MI
 2007,13140,"Beaumont, Port Arthur - TX"
 2008,13140,"Beaumont, Port Arthur - TX"
 2009,13140,"Beaumont, Port Arthur - TX"
 2010,13140,"Beaumont, Port Arthur - TX"
 2011,13140,"Beaumont, Port Arthur - TX"
 2012,13140,"Beaumont, Port Arthur - TX"
+2013,13140,"Beaumont, Port Arthur - TX"
 2007,13380,Bellingham - WA
 2008,13380,Bellingham - WA
 2009,13380,Bellingham - WA
 2010,13380,Bellingham - WA
 2011,13380,Bellingham - WA
 2012,13380,Bellingham - WA
+2013,13380,Bellingham - WA
 2007,13460,Bend - OR
 2008,13460,Bend - OR
 2009,13460,Bend - OR
 2010,13460,Bend - OR
 2011,13460,Bend - OR
 2012,13460,Bend - OR
+2013,13460,Bend - OR
+2007,13644,"Bethesda, Gaithersburg, Frederick - MD"
 2008,13644,"Bethesda, Frederick, Gaithersburg - MD"
 2009,13644,"Bethesda, Frederick, Rockville - MD"
-2007,13644,"Bethesda, Gaithersburg, Frederick - MD"
 2010,13644,"Bethesda, Rockville, Frederick - MD"
 2011,13644,"Bethesda, Rockville, Frederick - MD"
 2012,13644,"Bethesda, Rockville, Frederick - MD"
+2013,13644,"Bethesda, Rockville, Frederick - MD"
 2007,13740,Billings - MT
 2008,13740,Billings - MT
 2009,13740,Billings - MT
 2010,13740,Billings - MT
 2011,13740,Billings - MT
 2012,13740,Billings - MT
+2013,13740,Billings - MT
 2007,13780,Binghamton - NY
 2008,13780,Binghamton - NY
 2009,13780,Binghamton - NY
 2010,13780,Binghamton - NY
 2011,13780,Binghamton - NY
 2012,13780,Binghamton - NY
+2013,13780,Binghamton - NY
 2007,13820,"Birmingham, Hoover - AL"
 2008,13820,"Birmingham, Hoover - AL"
 2009,13820,"Birmingham, Hoover - AL"
 2010,13820,"Birmingham, Hoover - AL"
 2011,13820,"Birmingham, Hoover - AL"
 2012,13820,"Birmingham, Hoover - AL"
+2013,13820,"Birmingham, Hoover - AL"
 2007,13900,Bismarck - ND
 2008,13900,Bismarck - ND
 2009,13900,Bismarck - ND
 2010,13900,Bismarck - ND
 2011,13900,Bismarck - ND
 2012,13900,Bismarck - ND
+2013,13900,Bismarck - ND
 2007,13980,"Blacksburg, Christiansburg, Radford - VA"
 2008,13980,"Blacksburg, Christiansburg, Radford - VA"
 2009,13980,"Blacksburg, Christiansburg, Radford - VA"
 2010,13980,"Blacksburg, Christiansburg, Radford - VA"
 2011,13980,"Blacksburg, Christiansburg, Radford - VA"
 2012,13980,"Blacksburg, Christiansburg, Radford - VA"
+2013,13980,"Blacksburg, Christiansburg, Radford - VA"
 2007,14020,Bloomington - IN
 2008,14020,Bloomington - IN
 2009,14020,Bloomington - IN
 2010,14020,Bloomington - IN
 2011,14020,Bloomington - IN
 2012,14020,Bloomington - IN
+2013,14020,Bloomington - IN
 2007,14060,"Bloomington, Normal - IL"
 2008,14060,"Bloomington, Normal - IL"
 2009,14060,"Bloomington, Normal - IL"
 2010,14060,"Bloomington, Normal - IL"
 2011,14060,"Bloomington, Normal - IL"
 2012,14060,"Bloomington, Normal - IL"
+2013,14060,"Bloomington, Normal - IL"
 2007,14260,"Boise City, Nampa - ID"
 2008,14260,"Boise City, Nampa - ID"
 2009,14260,"Boise City, Nampa - ID"
 2010,14260,"Boise City, Nampa - ID"
 2011,14260,"Boise City, Nampa - ID"
 2012,14260,"Boise City, Nampa - ID"
+2013,14260,"Boise City, Nampa - ID"
 2007,14484,"Boston, Quincy - MA"
 2008,14484,"Boston, Quincy - MA"
 2009,14484,"Boston, Quincy - MA"
 2010,14484,"Boston, Quincy - MA"
 2011,14484,"Boston, Quincy - MA"
 2012,14484,"Boston, Quincy - MA"
+2013,14484,"Boston, Quincy - MA"
 2007,14500,Boulder - CO
 2008,14500,Boulder - CO
 2009,14500,Boulder - CO
 2010,14500,Boulder - CO
 2011,14500,Boulder - CO
 2012,14500,Boulder - CO
+2013,14500,Boulder - CO
 2007,14540,Bowling Green - KY
 2008,14540,Bowling Green - KY
 2009,14540,Bowling Green - KY
 2010,14540,Bowling Green - KY
 2011,14540,Bowling Green - KY
 2012,14540,Bowling Green - KY
+2013,14540,Bowling Green - KY
 2008,14600,"Bradenton, Sarasota, Venice - FL"
 2009,14600,"Bradenton, Sarasota, Venice - FL"
 2007,14740,"Bremerton, Silverdale - WA"
@@ -283,481 +329,562 @@ year,code,name
 2010,14740,"Bremerton, Silverdale - WA"
 2011,14740,"Bremerton, Silverdale - WA"
 2012,14740,"Bremerton, Silverdale - WA"
+2013,14740,"Bremerton, Silverdale - WA"
 2007,14860,"Bridgeport, Stamford, Norwalk - CT"
 2008,14860,"Bridgeport, Stamford, Norwalk - CT"
 2009,14860,"Bridgeport, Stamford, Norwalk - CT"
 2010,14860,"Bridgeport, Stamford, Norwalk - CT"
 2011,14860,"Bridgeport, Stamford, Norwalk - CT"
 2012,14860,"Bridgeport, Stamford, Norwalk - CT"
+2013,14860,"Bridgeport, Stamford, Norwalk - CT"
 2007,15180,"Brownsville, Harlingen - TX"
 2008,15180,"Brownsville, Harlingen - TX"
 2009,15180,"Brownsville, Harlingen - TX"
 2010,15180,"Brownsville, Harlingen - TX"
 2011,15180,"Brownsville, Harlingen - TX"
 2012,15180,"Brownsville, Harlingen - TX"
+2013,15180,"Brownsville, Harlingen - TX"
 2007,15260,Brunswick - GA
 2008,15260,Brunswick - GA
 2009,15260,Brunswick - GA
 2010,15260,Brunswick - GA
 2011,15260,Brunswick - GA
 2012,15260,Brunswick - GA
+2013,15260,Brunswick - GA
 2007,15380,"Buffalo, Niagara Falls - NY"
 2008,15380,"Buffalo, Niagara Falls - NY"
 2009,15380,"Buffalo, Niagara Falls - NY"
 2010,15380,"Buffalo, Niagara Falls - NY"
 2011,15380,"Buffalo, Niagara Falls - NY"
 2012,15380,"Buffalo, Niagara Falls - NY"
+2013,15380,"Buffalo, Niagara Falls - NY"
 2007,15500,Burlington - NC
 2008,15500,Burlington - NC
 2009,15500,Burlington - NC
 2010,15500,Burlington - NC
 2011,15500,Burlington - NC
 2012,15500,Burlington - NC
+2013,15500,Burlington - NC
 2007,15540,"Burlington, South Burlington - VT"
 2008,15540,"Burlington, South Burlington - VT"
 2009,15540,"Burlington, South Burlington - VT"
 2010,15540,"Burlington, South Burlington - VT"
 2011,15540,"Burlington, South Burlington - VT"
 2012,15540,"Burlington, South Burlington - VT"
+2013,15540,"Burlington, South Burlington - VT"
 2007,15764,"Cambridge, Newton, Framingham - MA"
 2008,15764,"Cambridge, Newton, Framingham - MA"
 2009,15764,"Cambridge, Newton, Framingham - MA"
 2010,15764,"Cambridge, Newton, Framingham - MA"
 2011,15764,"Cambridge, Newton, Framingham - MA"
 2012,15764,"Cambridge, Newton, Framingham - MA"
+2013,15764,"Cambridge, Newton, Framingham - MA"
 2007,15804,Camden - NJ
 2008,15804,Camden - NJ
 2009,15804,Camden - NJ
 2010,15804,Camden - NJ
 2011,15804,Camden - NJ
 2012,15804,Camden - NJ
+2013,15804,Camden - NJ
 2007,15940,"Canton, Massillon - OH"
 2008,15940,"Canton, Massillon - OH"
 2009,15940,"Canton, Massillon - OH"
 2010,15940,"Canton, Massillon - OH"
 2011,15940,"Canton, Massillon - OH"
 2012,15940,"Canton, Massillon - OH"
+2013,15940,"Canton, Massillon - OH"
 2007,15980,"Cape Coral, Fort Myers - FL"
 2008,15980,"Cape Coral, Fort Myers - FL"
 2009,15980,"Cape Coral, Fort Myers - FL"
 2010,15980,"Cape Coral, Fort Myers - FL"
 2011,15980,"Cape Coral, Fort Myers - FL"
 2012,15980,"Cape Coral, Fort Myers - FL"
+2013,15980,"Cape Coral, Fort Myers - FL"
 2009,16020,"Cape Girardeau, Jackson - MO, IL"
 2010,16020,"Cape Girardeau, Jackson - MO, IL"
 2011,16020,"Cape Girardeau, Jackson - MO, IL"
 2012,16020,"Cape Girardeau, Jackson - MO, IL"
+2013,16020,"Cape Girardeau, Jackson - MO, IL"
 2007,16180,Carson City - NV
 2008,16180,Carson City - NV
 2009,16180,Carson City - NV
 2010,16180,Carson City - NV
 2011,16180,Carson City - NV
 2012,16180,Carson City - NV
+2013,16180,Carson City - NV
 2007,16220,Casper - WY
 2008,16220,Casper - WY
 2009,16220,Casper - WY
 2010,16220,Casper - WY
 2011,16220,Casper - WY
 2012,16220,Casper - WY
+2013,16220,Casper - WY
 2007,16300,Cedar Rapids - IA
 2008,16300,Cedar Rapids - IA
 2009,16300,Cedar Rapids - IA
 2010,16300,Cedar Rapids - IA
 2011,16300,Cedar Rapids - IA
 2012,16300,Cedar Rapids - IA
+2013,16300,Cedar Rapids - IA
 2007,16580,"Champaign, Urbana - IL"
 2008,16580,"Champaign, Urbana - IL"
 2009,16580,"Champaign, Urbana - IL"
 2010,16580,"Champaign, Urbana - IL"
 2011,16580,"Champaign, Urbana - IL"
 2012,16580,"Champaign, Urbana - IL"
+2013,16580,"Champaign, Urbana - IL"
 2007,16620,Charleston - WV
 2008,16620,Charleston - WV
 2009,16620,Charleston - WV
 2010,16620,Charleston - WV
 2011,16620,Charleston - WV
 2012,16620,Charleston - WV
+2013,16620,Charleston - WV
 2007,16700,"Charleston, North Charleston - SC"
 2008,16700,"Charleston, North Charleston, Summerville - SC"
 2009,16700,"Charleston, North Charleston, Summerville - SC"
 2010,16700,"Charleston, North Charleston, Summerville - SC"
 2011,16700,"Charleston, North Charleston, Summerville - SC"
 2012,16700,"Charleston, North Charleston, Summerville - SC"
+2013,16700,"Charleston, North Charleston, Summerville - SC"
 2007,16740,"Charlotte, Gastonia, Concord - NC, SC"
 2008,16740,"Charlotte, Gastonia, Concord - NC, SC"
 2009,16740,"Charlotte, Gastonia, Concord - NC, SC"
 2010,16740,"Charlotte, Gastonia, Rock Hill - NC, SC"
 2011,16740,"Charlotte, Gastonia, Rock Hill - NC, SC"
 2012,16740,"Charlotte, Gastonia, Rock Hill - NC, SC"
+2013,16740,"Charlotte, Gastonia, Rock Hill - NC, SC"
 2007,16820,Charlottesville - VA
 2008,16820,Charlottesville - VA
 2009,16820,Charlottesville - VA
 2010,16820,Charlottesville - VA
 2011,16820,Charlottesville - VA
 2012,16820,Charlottesville - VA
+2013,16820,Charlottesville - VA
 2007,16860,"Chattanooga - TN, GA"
 2008,16860,"Chattanooga - TN, GA"
 2009,16860,"Chattanooga - TN, GA"
 2010,16860,"Chattanooga - TN, GA"
 2011,16860,"Chattanooga - TN, GA"
 2012,16860,"Chattanooga - TN, GA"
+2013,16860,"Chattanooga - TN, GA"
 2007,16940,Cheyenne - WY
 2008,16940,Cheyenne - WY
 2009,16940,Cheyenne - WY
 2010,16940,Cheyenne - WY
 2011,16940,Cheyenne - WY
 2012,16940,Cheyenne - WY
-2010,16974,"Chicago, Joliet, Naperville - IL"
-2011,16974,"Chicago, Joliet, Naperville - IL"
-2012,16974,"Chicago, Joliet, Naperville - IL"
+2013,16940,Cheyenne - WY
 2007,16974,"Chicago, Naperville, Joliet - IL"
 2008,16974,"Chicago, Naperville, Joliet - IL"
 2009,16974,"Chicago, Naperville, Joliet - IL"
+2010,16974,"Chicago, Joliet, Naperville - IL"
+2011,16974,"Chicago, Joliet, Naperville - IL"
+2012,16974,"Chicago, Joliet, Naperville - IL"
+2013,16974,"Chicago, Joliet, Naperville - IL"
 2007,17020,Chico - CA
 2008,17020,Chico - CA
 2009,17020,Chico - CA
 2010,17020,Chico - CA
 2011,17020,Chico - CA
 2012,17020,Chico - CA
+2013,17020,Chico - CA
 2007,17140,"Cincinnati, Middletown - OH, KY, IN"
 2008,17140,"Cincinnati, Middletown - OH, KY, IN"
 2009,17140,"Cincinnati, Middletown - OH, KY, IN"
 2010,17140,"Cincinnati, Middletown - OH, KY, IN"
 2011,17140,"Cincinnati, Middletown - OH, KY, IN"
 2012,17140,"Cincinnati, Middletown - OH, KY, IN"
+2013,17140,"Cincinnati, Middletown - OH, KY, IN"
 2007,17300,"Clarksville - TN, KY"
 2008,17300,"Clarksville - TN, KY"
 2009,17300,"Clarksville - TN, KY"
 2010,17300,"Clarksville - TN, KY"
 2011,17300,"Clarksville - TN, KY"
 2012,17300,"Clarksville - TN, KY"
+2013,17300,"Clarksville - TN, KY"
 2007,17420,Cleveland - TN
 2008,17420,Cleveland - TN
 2009,17420,Cleveland - TN
 2010,17420,Cleveland - TN
 2011,17420,Cleveland - TN
 2012,17420,Cleveland - TN
+2013,17420,Cleveland - TN
 2007,17460,"Cleveland, Elyria, Mentor - OH"
 2008,17460,"Cleveland, Elyria, Mentor - OH"
 2009,17460,"Cleveland, Elyria, Mentor - OH"
 2010,17460,"Cleveland, Elyria, Mentor - OH"
 2011,17460,"Cleveland, Elyria, Mentor - OH"
 2012,17460,"Cleveland, Elyria, Mentor - OH"
+2013,17460,"Cleveland, Elyria, Mentor - OH"
 2007,17660,Coeur D'Alene - ID
 2008,17660,Coeur D'Alene - ID
 2009,17660,Coeur D'Alene - ID
 2010,17660,Coeur D'Alene - ID
 2011,17660,Coeur D'Alene - ID
 2012,17660,Coeur D'Alene - ID
+2013,17660,Coeur D'Alene - ID
 2007,17780,"College Station, Bryan - TX"
 2008,17780,"College Station, Bryan - TX"
 2009,17780,"College Station, Bryan - TX"
 2010,17780,"College Station, Bryan - TX"
 2011,17780,"College Station, Bryan - TX"
 2012,17780,"College Station, Bryan - TX"
+2013,17780,"College Station, Bryan - TX"
 2007,17820,Colorado Springs - CO
 2008,17820,Colorado Springs - CO
 2009,17820,Colorado Springs - CO
 2010,17820,Colorado Springs - CO
 2011,17820,Colorado Springs - CO
 2012,17820,Colorado Springs - CO
+2013,17820,Colorado Springs - CO
 2007,17860,Columbia - MO
 2008,17860,Columbia - MO
 2009,17860,Columbia - MO
 2010,17860,Columbia - MO
 2011,17860,Columbia - MO
 2012,17860,Columbia - MO
+2013,17860,Columbia - MO
 2007,17900,Columbia - SC
 2008,17900,Columbia - SC
 2009,17900,Columbia - SC
 2010,17900,Columbia - SC
 2011,17900,Columbia - SC
 2012,17900,Columbia - SC
+2013,17900,Columbia - SC
 2007,17980,"Columbus - GA, AL"
 2008,17980,"Columbus - GA, AL"
 2009,17980,"Columbus - GA, AL"
 2010,17980,"Columbus - GA, AL"
 2011,17980,"Columbus - GA, AL"
 2012,17980,"Columbus - GA, AL"
+2013,17980,"Columbus - GA, AL"
 2007,18020,Columbus - IN
 2008,18020,Columbus - IN
 2009,18020,Columbus - IN
 2010,18020,Columbus - IN
 2011,18020,Columbus - IN
 2012,18020,Columbus - IN
+2013,18020,Columbus - IN
 2007,18140,Columbus - OH
 2008,18140,Columbus - OH
 2009,18140,Columbus - OH
 2010,18140,Columbus - OH
 2011,18140,Columbus - OH
 2012,18140,Columbus - OH
+2013,18140,Columbus - OH
 2007,18580,Corpus Christi - TX
 2008,18580,Corpus Christi - TX
 2009,18580,Corpus Christi - TX
 2010,18580,Corpus Christi - TX
 2011,18580,Corpus Christi - TX
 2012,18580,Corpus Christi - TX
+2013,18580,Corpus Christi - TX
 2007,18700,Corvallis - OR
 2008,18700,Corvallis - OR
 2009,18700,Corvallis - OR
 2010,18700,Corvallis - OR
 2011,18700,Corvallis - OR
 2012,18700,Corvallis - OR
+2013,18700,Corvallis - OR
 2010,18880,"Crestview, Fort Walton Beach, Destin - FL"
 2011,18880,"Crestview, Fort Walton Beach, Destin - FL"
 2012,18880,"Crestview, Fort Walton Beach, Destin - FL"
+2013,18880,"Crestview, Fort Walton Beach, Destin - FL"
 2007,19060,"Cumberland - MD, WV"
 2008,19060,"Cumberland - MD, WV"
 2009,19060,"Cumberland - MD, WV"
 2010,19060,"Cumberland - MD, WV"
 2011,19060,"Cumberland - MD, WV"
 2012,19060,"Cumberland - MD, WV"
+2013,19060,"Cumberland - MD, WV"
 2007,19124,"Dallas, Plano, Irving - TX"
 2008,19124,"Dallas, Plano, Irving - TX"
 2009,19124,"Dallas, Plano, Irving - TX"
 2010,19124,"Dallas, Plano, Irving - TX"
 2011,19124,"Dallas, Plano, Irving - TX"
 2012,19124,"Dallas, Plano, Irving - TX"
+2013,19124,"Dallas, Plano, Irving - TX"
 2007,19140,Dalton - GA
 2008,19140,Dalton - GA
 2009,19140,Dalton - GA
 2010,19140,Dalton - GA
 2011,19140,Dalton - GA
 2012,19140,Dalton - GA
+2013,19140,Dalton - GA
 2007,19180,Danville - IL
 2008,19180,Danville - IL
 2009,19180,Danville - IL
 2010,19180,Danville - IL
 2011,19180,Danville - IL
 2012,19180,Danville - IL
+2013,19180,Danville - IL
 2007,19260,Danville - VA
 2008,19260,Danville - VA
 2009,19260,Danville - VA
 2010,19260,Danville - VA
 2011,19260,Danville - VA
 2012,19260,Danville - VA
+2013,19260,Danville - VA
 2007,19340,"Davenport, Moline, Rock Island - IA, IL"
 2008,19340,"Davenport, Moline, Rock Island - IA, IL"
 2009,19340,"Davenport, Moline, Rock Island - IA, IL"
 2010,19340,"Davenport, Moline, Rock Island - IA, IL"
 2011,19340,"Davenport, Moline, Rock Island - IA, IL"
 2012,19340,"Davenport, Moline, Rock Island - IA, IL"
+2013,19340,"Davenport, Moline, Rock Island - IA, IL"
 2007,19380,Dayton - OH
 2008,19380,Dayton - OH
 2009,19380,Dayton - OH
 2010,19380,Dayton - OH
 2011,19380,Dayton - OH
 2012,19380,Dayton - OH
+2013,19380,Dayton - OH
 2007,19460,Decatur - AL
 2008,19460,Decatur - AL
 2009,19460,Decatur - AL
 2010,19460,Decatur - AL
 2011,19460,Decatur - AL
 2012,19460,Decatur - AL
+2013,19460,Decatur - AL
 2007,19500,Decatur - IL
 2008,19500,Decatur - IL
 2009,19500,Decatur - IL
 2010,19500,Decatur - IL
 2011,19500,Decatur - IL
 2012,19500,Decatur - IL
+2013,19500,Decatur - IL
 2007,19660,"Deltona, Daytona Beach, Ormond Beach - FL"
 2008,19660,"Deltona, Daytona Beach, Ormond Beach - FL"
 2009,19660,"Deltona, Daytona Beach, Ormond Beach - FL"
 2010,19660,"Deltona, Daytona Beach, Ormond Beach - FL"
 2011,19660,"Deltona, Daytona Beach, Ormond Beach - FL"
 2012,19660,"Deltona, Daytona Beach, Ormond Beach - FL"
+2013,19660,"Deltona, Daytona Beach, Ormond Beach - FL"
 2007,19740,"Denver, Aurora - CO"
 2008,19740,"Denver, Aurora - CO"
 2009,19740,"Denver, Aurora, Broomfield - CO"
 2010,19740,"Denver, Aurora, Broomfield - CO"
 2011,19740,"Denver, Aurora, Broomfield - CO"
 2012,19740,"Denver, Aurora, Broomfield - CO"
+2013,19740,"Denver, Aurora, Broomfield - CO"
 2007,19780,"Des Moines, West Des Moines - IA"
 2008,19780,"Des Moines, West Des Moines - IA"
 2009,19780,"Des Moines, West Des Moines - IA"
 2010,19780,"Des Moines, West Des Moines - IA"
 2011,19780,"Des Moines, West Des Moines - IA"
 2012,19780,"Des Moines, West Des Moines - IA"
+2013,19780,"Des Moines, West Des Moines - IA"
 2007,19804,"Detroit, Livonia, Dearborn - MI"
 2008,19804,"Detroit, Livonia, Dearborn - MI"
 2009,19804,"Detroit, Livonia, Dearborn - MI"
 2010,19804,"Detroit, Livonia, Dearborn - MI"
 2011,19804,"Detroit, Livonia, Dearborn - MI"
 2012,19804,"Detroit, Livonia, Dearborn - MI"
+2013,19804,"Detroit, Livonia, Dearborn - MI"
 2007,20020,Dothan - AL
 2008,20020,Dothan - AL
 2009,20020,Dothan - AL
 2010,20020,Dothan - AL
 2011,20020,Dothan - AL
 2012,20020,Dothan - AL
+2013,20020,Dothan - AL
 2007,20100,Dover - DE
 2008,20100,Dover - DE
 2009,20100,Dover - DE
 2010,20100,Dover - DE
 2011,20100,Dover - DE
 2012,20100,Dover - DE
+2013,20100,Dover - DE
 2007,20220,Dubuque - IA
 2008,20220,Dubuque - IA
 2009,20220,Dubuque - IA
 2010,20220,Dubuque - IA
 2011,20220,Dubuque - IA
 2012,20220,Dubuque - IA
+2013,20220,Dubuque - IA
 2007,20260,"Duluth - MN, WI"
 2008,20260,"Duluth - MN, WI"
 2009,20260,"Duluth - MN, WI"
 2010,20260,"Duluth - MN, WI"
 2011,20260,"Duluth - MN, WI"
 2012,20260,"Duluth - MN, WI"
+2013,20260,"Duluth - MN, WI"
 2007,20500,Durham - NC
 2008,20500,Durham - NC
 2009,20500,"Durham, Chapel Hill - NC"
 2010,20500,"Durham, Chapel Hill - NC"
 2011,20500,"Durham, Chapel Hill - NC"
 2012,20500,"Durham, Chapel Hill - NC"
+2013,20500,"Durham, Chapel Hill - NC"
 2007,20740,Eau Claire - WI
 2008,20740,Eau Claire - WI
 2009,20740,Eau Claire - WI
 2010,20740,Eau Claire - WI
 2011,20740,Eau Claire - WI
 2012,20740,Eau Claire - WI
+2013,20740,Eau Claire - WI
 2007,20764,Edison - NJ
 2008,20764,"Edison, New Brunswick - NJ"
 2009,20764,"Edison, New Brunswick - NJ"
 2010,20764,"Edison, New Brunswick - NJ"
 2011,20764,"Edison, New Brunswick - NJ"
 2012,20764,"Edison, New Brunswick - NJ"
+2013,20764,"Edison, New Brunswick - NJ"
 2007,20940,El Centro - CA
 2008,20940,El Centro - CA
 2009,20940,El Centro - CA
 2010,20940,El Centro - CA
 2011,20940,El Centro - CA
 2012,20940,El Centro - CA
-2007,21340,El Paso - TX
-2008,21340,El Paso - TX
-2009,21340,El Paso - TX
-2010,21340,El Paso - TX
-2011,21340,El Paso - TX
-2012,21340,El Paso - TX
+2013,20940,El Centro - CA
 2007,21060,Elizabethtown - KY
 2008,21060,Elizabethtown - KY
 2009,21060,Elizabethtown - KY
 2010,21060,Elizabethtown - KY
 2011,21060,Elizabethtown - KY
 2012,21060,Elizabethtown - KY
+2013,21060,Elizabethtown - KY
 2007,21140,"Elkhart, Goshen - IN"
 2008,21140,"Elkhart, Goshen - IN"
 2009,21140,"Elkhart, Goshen - IN"
 2010,21140,"Elkhart, Goshen - IN"
 2011,21140,"Elkhart, Goshen - IN"
 2012,21140,"Elkhart, Goshen - IN"
+2013,21140,"Elkhart, Goshen - IN"
 2007,21300,Elmira - NY
 2008,21300,Elmira - NY
 2009,21300,Elmira - NY
 2010,21300,Elmira - NY
 2011,21300,Elmira - NY
 2012,21300,Elmira - NY
+2013,21300,Elmira - NY
+2007,21340,El Paso - TX
+2008,21340,El Paso - TX
+2009,21340,El Paso - TX
+2010,21340,El Paso - TX
+2011,21340,El Paso - TX
+2012,21340,El Paso - TX
+2013,21340,El Paso - TX
 2007,21500,Erie - PA
 2008,21500,Erie - PA
 2009,21500,Erie - PA
 2010,21500,Erie - PA
 2011,21500,Erie - PA
 2012,21500,Erie - PA
+2013,21500,Erie - PA
 2007,21660,"Eugene, Springfield - OR"
 2008,21660,"Eugene, Springfield - OR"
 2009,21660,"Eugene, Springfield - OR"
 2010,21660,"Eugene, Springfield - OR"
 2011,21660,"Eugene, Springfield - OR"
 2012,21660,"Eugene, Springfield - OR"
+2013,21660,"Eugene, Springfield - OR"
 2007,21780,"Evansville - IN, KY"
 2008,21780,"Evansville - IN, KY"
 2009,21780,"Evansville - IN, KY"
 2010,21780,"Evansville - IN, KY"
 2011,21780,"Evansville - IN, KY"
 2012,21780,"Evansville - IN, KY"
+2013,21780,"Evansville - IN, KY"
 2007,21820,Fairbanks - AK
 2008,21820,Fairbanks - AK
 2009,21820,Fairbanks - AK
 2010,21820,Fairbanks - AK
 2011,21820,Fairbanks - AK
 2012,21820,Fairbanks - AK
+2013,21820,Fairbanks - AK
 2007,21940,Fajardo - PR
 2008,21940,Fajardo - PR
 2009,21940,Fajardo - PR
 2010,21940,Fajardo - PR
 2011,21940,Fajardo - PR
 2012,21940,Fajardo - PR
+2013,21940,Fajardo - PR
 2007,22020,"Fargo - ND, MN"
 2008,22020,"Fargo - ND, MN"
 2009,22020,"Fargo - ND, MN"
 2010,22020,"Fargo - ND, MN"
 2011,22020,"Fargo - ND, MN"
 2012,22020,"Fargo - ND, MN"
+2013,22020,"Fargo - ND, MN"
 2007,22140,Farmington - NM
 2008,22140,Farmington - NM
 2009,22140,Farmington - NM
 2010,22140,Farmington - NM
 2011,22140,Farmington - NM
 2012,22140,Farmington - NM
+2013,22140,Farmington - NM
 2007,22180,Fayetteville - NC
 2008,22180,Fayetteville - NC
 2009,22180,Fayetteville - NC
 2010,22180,Fayetteville - NC
 2011,22180,Fayetteville - NC
 2012,22180,Fayetteville - NC
+2013,22180,Fayetteville - NC
 2007,22220,"Fayetteville, Springdale, Rogers - AR, MO"
 2008,22220,"Fayetteville, Springdale, Rogers - AR, MO"
 2009,22220,"Fayetteville, Springdale, Rogers - AR, MO"
 2010,22220,"Fayetteville, Springdale, Rogers - AR, MO"
 2011,22220,"Fayetteville, Springdale, Rogers - AR, MO"
 2012,22220,"Fayetteville, Springdale, Rogers - AR, MO"
+2013,22220,"Fayetteville, Springdale, Rogers - AR, MO"
 2007,22380,Flagstaff - AZ
 2008,22380,Flagstaff - AZ
 2009,22380,Flagstaff - AZ
 2010,22380,Flagstaff - AZ
 2011,22380,Flagstaff - AZ
 2012,22380,Flagstaff - AZ
+2013,22380,Flagstaff - AZ
 2007,22420,Flint - MI
 2008,22420,Flint - MI
 2009,22420,Flint - MI
 2010,22420,Flint - MI
 2011,22420,Flint - MI
 2012,22420,Flint - MI
+2013,22420,Flint - MI
 2007,22500,Florence - SC
 2008,22500,Florence - SC
 2009,22500,Florence - SC
 2010,22500,Florence - SC
 2011,22500,Florence - SC
 2012,22500,Florence - SC
+2013,22500,Florence - SC
 2007,22520,"Florence, Muscle Shoals - AL"
 2008,22520,"Florence, Muscle Shoals - AL"
 2009,22520,"Florence, Muscle Shoals - AL"
 2010,22520,"Florence, Muscle Shoals - AL"
 2011,22520,"Florence, Muscle Shoals - AL"
 2012,22520,"Florence, Muscle Shoals - AL"
+2013,22520,"Florence, Muscle Shoals - AL"
 2007,22540,Fond du Lac - WI
 2008,22540,Fond du Lac - WI
 2009,22540,Fond du Lac - WI
 2010,22540,Fond du Lac - WI
 2011,22540,Fond du Lac - WI
 2012,22540,Fond du Lac - WI
+2013,22540,Fond du Lac - WI
 2007,22660,"Fort Collins, Loveland - CO"
 2008,22660,"Fort Collins, Loveland - CO"
 2009,22660,"Fort Collins, Loveland - CO"
 2010,22660,"Fort Collins, Loveland - CO"
 2011,22660,"Fort Collins, Loveland - CO"
 2012,22660,"Fort Collins, Loveland - CO"
+2013,22660,"Fort Collins, Loveland - CO"
 2007,22744,"Fort Lauderdale, Pompano Beach, Deerfield Beach - FL"
 2008,22744,"Fort Lauderdale, Pompano Beach, Deerfield Beach - FL"
 2009,22744,"Fort Lauderdale, Pompano Beach, Deerfield Beach - FL"
 2010,22744,"Fort Lauderdale, Pompano Beach, Deerfield Beach - FL"
 2011,22744,"Fort Lauderdale, Pompano Beach, Deerfield Beach - FL"
 2012,22744,"Fort Lauderdale, Pompano Beach, Deerfield Beach - FL"
+2013,22744,"Fort Lauderdale, Pompano Beach, Deerfield Beach - FL"
 2007,22900,"Fort Smith - AR, OK"
 2008,22900,"Fort Smith - AR, OK"
 2009,22900,"Fort Smith - AR, OK"
 2010,22900,"Fort Smith - AR, OK"
 2011,22900,"Fort Smith - AR, OK"
 2012,22900,"Fort Smith - AR, OK"
+2013,22900,"Fort Smith - AR, OK"
 2007,23020,"Fort Walton Beach, Crestview, Destin - FL"
 2008,23020,"Fort Walton Beach, Crestview, Destin - FL"
 2009,23020,"Fort Walton Beach, Crestview, Destin - FL"
@@ -767,1187 +894,1407 @@ year,code,name
 2010,23060,Fort Wayne - IN
 2011,23060,Fort Wayne - IN
 2012,23060,Fort Wayne - IN
+2013,23060,Fort Wayne - IN
 2007,23104,"Fort Worth, Arlington - TX"
 2008,23104,"Fort Worth, Arlington - TX"
 2009,23104,"Fort Worth, Arlington - TX"
 2010,23104,"Fort Worth, Arlington - TX"
 2011,23104,"Fort Worth, Arlington - TX"
 2012,23104,"Fort Worth, Arlington - TX"
+2013,23104,"Fort Worth, Arlington - TX"
 2007,23420,Fresno - CA
 2008,23420,Fresno - CA
 2009,23420,Fresno - CA
 2010,23420,Fresno - CA
 2011,23420,Fresno - CA
 2012,23420,Fresno - CA
+2013,23420,Fresno - CA
 2007,23460,Gadsden - AL
 2008,23460,Gadsden - AL
 2009,23460,Gadsden - AL
 2010,23460,Gadsden - AL
 2011,23460,Gadsden - AL
 2012,23460,Gadsden - AL
+2013,23460,Gadsden - AL
 2007,23540,Gainesville - FL
 2008,23540,Gainesville - FL
 2009,23540,Gainesville - FL
 2010,23540,Gainesville - FL
 2011,23540,Gainesville - FL
 2012,23540,Gainesville - FL
+2013,23540,Gainesville - FL
 2007,23580,Gainesville - GA
 2008,23580,Gainesville - GA
 2009,23580,Gainesville - GA
 2010,23580,Gainesville - GA
 2011,23580,Gainesville - GA
 2012,23580,Gainesville - GA
+2013,23580,Gainesville - GA
 2007,23844,Gary - IN
 2008,23844,Gary - IN
 2009,23844,Gary - IN
 2010,23844,Gary - IN
 2011,23844,Gary - IN
 2012,23844,Gary - IN
+2013,23844,Gary - IN
 2007,24020,Glens Falls - NY
 2008,24020,Glens Falls - NY
 2009,24020,Glens Falls - NY
 2010,24020,Glens Falls - NY
 2011,24020,Glens Falls - NY
 2012,24020,Glens Falls - NY
+2013,24020,Glens Falls - NY
 2007,24140,Goldsboro - NC
 2008,24140,Goldsboro - NC
 2009,24140,Goldsboro - NC
 2010,24140,Goldsboro - NC
 2011,24140,Goldsboro - NC
 2012,24140,Goldsboro - NC
+2013,24140,Goldsboro - NC
 2007,24220,"Grand Forks - ND, MN"
 2008,24220,"Grand Forks - ND, MN"
 2009,24220,"Grand Forks - ND, MN"
 2010,24220,"Grand Forks - ND, MN"
 2011,24220,"Grand Forks - ND, MN"
 2012,24220,"Grand Forks - ND, MN"
+2013,24220,"Grand Forks - ND, MN"
 2007,24300,Grand Junction - CO
 2008,24300,Grand Junction - CO
 2009,24300,Grand Junction - CO
 2010,24300,Grand Junction - CO
 2011,24300,Grand Junction - CO
 2012,24300,Grand Junction - CO
+2013,24300,Grand Junction - CO
 2007,24340,"Grand Rapids, Wyoming - MI"
 2008,24340,"Grand Rapids, Wyoming - MI"
 2009,24340,"Grand Rapids, Wyoming - MI"
 2010,24340,"Grand Rapids, Wyoming - MI"
 2011,24340,"Grand Rapids, Wyoming - MI"
 2012,24340,"Grand Rapids, Wyoming - MI"
+2013,24340,"Grand Rapids, Wyoming - MI"
 2007,24500,Great Falls - MT
 2008,24500,Great Falls - MT
 2009,24500,Great Falls - MT
 2010,24500,Great Falls - MT
 2011,24500,Great Falls - MT
 2012,24500,Great Falls - MT
+2013,24500,Great Falls - MT
 2007,24540,Greeley - CO
 2008,24540,Greeley - CO
 2009,24540,Greeley - CO
 2010,24540,Greeley - CO
 2011,24540,Greeley - CO
 2012,24540,Greeley - CO
+2013,24540,Greeley - CO
 2007,24580,Green Bay - WI
 2008,24580,Green Bay - WI
 2009,24580,Green Bay - WI
 2010,24580,Green Bay - WI
 2011,24580,Green Bay - WI
 2012,24580,Green Bay - WI
+2013,24580,Green Bay - WI
 2007,24660,"Greensboro, High Point - NC"
 2008,24660,"Greensboro, High Point - NC"
 2009,24660,"Greensboro, High Point - NC"
 2010,24660,"Greensboro, High Point - NC"
 2011,24660,"Greensboro, High Point - NC"
 2012,24660,"Greensboro, High Point - NC"
+2013,24660,"Greensboro, High Point - NC"
 2007,24780,Greenville - NC
 2008,24780,Greenville - NC
 2009,24780,Greenville - NC
 2010,24780,Greenville - NC
 2011,24780,Greenville - NC
 2012,24780,Greenville - NC
+2013,24780,Greenville - NC
 2007,24860,"Greenville, Mauldin, Easley - SC"
 2008,24860,"Greenville, Mauldin, Easley - SC"
 2009,24860,"Greenville, Mauldin, Easley - SC"
 2010,24860,"Greenville, Mauldin, Easley - SC"
 2011,24860,"Greenville, Mauldin, Easley - SC"
 2012,24860,"Greenville, Mauldin, Easley - SC"
+2013,24860,"Greenville, Mauldin, Easley - SC"
 2007,25020,Guayama - PR
 2008,25020,Guayama - PR
 2009,25020,Guayama - PR
 2010,25020,Guayama - PR
 2011,25020,Guayama - PR
 2012,25020,Guayama - PR
+2013,25020,Guayama - PR
 2007,25060,"Gulfport, Biloxi - MS"
 2008,25060,"Gulfport, Biloxi - MS"
 2009,25060,"Gulfport, Biloxi - MS"
 2010,25060,"Gulfport, Biloxi - MS"
 2011,25060,"Gulfport, Biloxi - MS"
 2012,25060,"Gulfport, Biloxi - MS"
+2013,25060,"Gulfport, Biloxi - MS"
 2007,25180,"Hagerstown, Martinsburg - MD, WV"
 2008,25180,"Hagerstown, Martinsburg - MD, WV"
 2009,25180,"Hagerstown, Martinsburg - MD, WV"
 2010,25180,"Hagerstown, Martinsburg - MD, WV"
 2011,25180,"Hagerstown, Martinsburg - MD, WV"
 2012,25180,"Hagerstown, Martinsburg - MD, WV"
+2013,25180,"Hagerstown, Martinsburg - MD, WV"
 2007,25260,"Hanford, Corcoran - CA"
 2008,25260,"Hanford, Corcoran - CA"
 2009,25260,"Hanford, Corcoran - CA"
 2010,25260,"Hanford, Corcoran - CA"
 2011,25260,"Hanford, Corcoran - CA"
 2012,25260,"Hanford, Corcoran - CA"
+2013,25260,"Hanford, Corcoran - CA"
 2007,25420,"Harrisburg, Carlisle - PA"
 2008,25420,"Harrisburg, Carlisle - PA"
 2009,25420,"Harrisburg, Carlisle - PA"
 2010,25420,"Harrisburg, Carlisle - PA"
 2011,25420,"Harrisburg, Carlisle - PA"
 2012,25420,"Harrisburg, Carlisle - PA"
+2013,25420,"Harrisburg, Carlisle - PA"
 2007,25500,Harrisonburg - VA
 2008,25500,Harrisonburg - VA
 2009,25500,Harrisonburg - VA
 2010,25500,Harrisonburg - VA
 2011,25500,Harrisonburg - VA
 2012,25500,Harrisonburg - VA
+2013,25500,Harrisonburg - VA
 2007,25540,"Hartford, West Hartford, East Hartford - CT"
 2008,25540,"Hartford, West Hartford, East Hartford - CT"
 2009,25540,"Hartford, West Hartford, East Hartford - CT"
 2010,25540,"Hartford, West Hartford, East Hartford - CT"
 2011,25540,"Hartford, West Hartford, East Hartford - CT"
 2012,25540,"Hartford, West Hartford, East Hartford - CT"
+2013,25540,"Hartford, West Hartford, East Hartford - CT"
 2007,25620,Hattiesburg - MS
 2008,25620,Hattiesburg - MS
 2009,25620,Hattiesburg - MS
 2010,25620,Hattiesburg - MS
 2011,25620,Hattiesburg - MS
 2012,25620,Hattiesburg - MS
+2013,25620,Hattiesburg - MS
 2007,25860,"Hickory, Lenoir, Morganton - NC"
 2008,25860,"Hickory, Lenoir, Morganton - NC"
 2009,25860,"Hickory, Lenoir, Morganton - NC"
 2010,25860,"Hickory, Lenoir, Morganton - NC"
 2011,25860,"Hickory, Lenoir, Morganton - NC"
 2012,25860,"Hickory, Lenoir, Morganton - NC"
+2013,25860,"Hickory, Lenoir, Morganton - NC"
 2007,25980,"Hinesville, Fort Stewart - GA"
 2008,25980,"Hinesville, Fort Stewart - GA"
 2009,25980,"Hinesville, Fort Stewart - GA"
 2010,25980,"Hinesville, Fort Stewart - GA"
 2011,25980,"Hinesville, Fort Stewart - GA"
 2012,25980,"Hinesville, Fort Stewart - GA"
+2013,25980,"Hinesville, Fort Stewart - GA"
 2007,26100,"Holland, Grand Haven - MI"
 2008,26100,"Holland, Grand Haven - MI"
 2009,26100,"Holland, Grand Haven - MI"
 2010,26100,"Holland, Grand Haven - MI"
 2011,26100,"Holland, Grand Haven - MI"
 2012,26100,"Holland, Grand Haven - MI"
+2013,26100,"Holland, Grand Haven - MI"
 2007,26180,Honolulu - HI
 2008,26180,Honolulu - HI
 2009,26180,Honolulu - HI
 2010,26180,Honolulu - HI
 2011,26180,Honolulu - HI
 2012,26180,Honolulu - HI
+2013,26180,Honolulu - HI
 2007,26300,Hot Springs - AR
 2008,26300,Hot Springs - AR
 2009,26300,Hot Springs - AR
 2010,26300,Hot Springs - AR
 2011,26300,Hot Springs - AR
 2012,26300,Hot Springs - AR
+2013,26300,Hot Springs - AR
 2007,26380,"Houma, Bayou Cane, Thibodaux - LA"
 2008,26380,"Houma, Bayou Cane, Thibodaux - LA"
 2009,26380,"Houma, Bayou Cane, Thibodaux - LA"
 2010,26380,"Houma, Bayou Cane, Thibodaux - LA"
 2011,26380,"Houma, Bayou Cane, Thibodaux - LA"
 2012,26380,"Houma, Bayou Cane, Thibodaux - LA"
+2013,26380,"Houma, Bayou Cane, Thibodaux - LA"
 2007,26420,"Houston, Sugar Land, Baytown - TX"
 2008,26420,"Houston, Sugar Land, Baytown - TX"
 2009,26420,"Houston, Sugar Land, Baytown - TX"
 2010,26420,"Houston, Sugar Land, Baytown - TX"
 2011,26420,"Houston, Sugar Land, Baytown - TX"
 2012,26420,"Houston, Sugar Land, Baytown - TX"
+2013,26420,"Houston, Sugar Land, Baytown - TX"
 2007,26580,"Huntington, Ashland - WV, KY, OH"
 2008,26580,"Huntington, Ashland - WV, KY, OH"
 2009,26580,"Huntington, Ashland - WV, KY, OH"
 2010,26580,"Huntington, Ashland - WV, KY, OH"
 2011,26580,"Huntington, Ashland - WV, KY, OH"
 2012,26580,"Huntington, Ashland - WV, KY, OH"
+2013,26580,"Huntington, Ashland - WV, KY, OH"
 2007,26620,Huntsville - AL
 2008,26620,Huntsville - AL
 2009,26620,Huntsville - AL
 2010,26620,Huntsville - AL
 2011,26620,Huntsville - AL
 2012,26620,Huntsville - AL
+2013,26620,Huntsville - AL
 2007,26820,Idaho Falls - ID
 2008,26820,Idaho Falls - ID
 2009,26820,Idaho Falls - ID
 2010,26820,Idaho Falls - ID
 2011,26820,Idaho Falls - ID
 2012,26820,Idaho Falls - ID
+2013,26820,Idaho Falls - ID
 2007,26900,"Indianapolis, Carmel - IN"
 2008,26900,"Indianapolis, Carmel - IN"
 2009,26900,"Indianapolis, Carmel - IN"
 2010,26900,"Indianapolis, Carmel - IN"
 2011,26900,"Indianapolis, Carmel - IN"
 2012,26900,"Indianapolis, Carmel - IN"
+2013,26900,"Indianapolis, Carmel - IN"
 2007,26980,Iowa City - IA
 2008,26980,Iowa City - IA
 2009,26980,Iowa City - IA
 2010,26980,Iowa City - IA
 2011,26980,Iowa City - IA
 2012,26980,Iowa City - IA
+2013,26980,Iowa City - IA
 2007,27060,Ithaca - NY
 2008,27060,Ithaca - NY
 2009,27060,Ithaca - NY
 2010,27060,Ithaca - NY
 2011,27060,Ithaca - NY
 2012,27060,Ithaca - NY
+2013,27060,Ithaca - NY
 2007,27100,Jackson - MI
 2008,27100,Jackson - MI
 2009,27100,Jackson - MI
 2010,27100,Jackson - MI
 2011,27100,Jackson - MI
 2012,27100,Jackson - MI
+2013,27100,Jackson - MI
 2007,27140,Jackson - MS
 2008,27140,Jackson - MS
 2009,27140,Jackson - MS
 2010,27140,Jackson - MS
 2011,27140,Jackson - MS
 2012,27140,Jackson - MS
+2013,27140,Jackson - MS
 2007,27180,Jackson - TN
 2008,27180,Jackson - TN
 2009,27180,Jackson - TN
 2010,27180,Jackson - TN
 2011,27180,Jackson - TN
 2012,27180,Jackson - TN
+2013,27180,Jackson - TN
 2007,27260,Jacksonville - FL
 2008,27260,Jacksonville - FL
 2009,27260,Jacksonville - FL
 2010,27260,Jacksonville - FL
 2011,27260,Jacksonville - FL
 2012,27260,Jacksonville - FL
+2013,27260,Jacksonville - FL
 2007,27340,Jacksonville - NC
 2008,27340,Jacksonville - NC
 2009,27340,Jacksonville - NC
 2010,27340,Jacksonville - NC
 2011,27340,Jacksonville - NC
 2012,27340,Jacksonville - NC
+2013,27340,Jacksonville - NC
 2007,27500,Janesville - WI
 2008,27500,Janesville - WI
 2009,27500,Janesville - WI
 2010,27500,Janesville - WI
 2011,27500,Janesville - WI
 2012,27500,Janesville - WI
+2013,27500,Janesville - WI
 2007,27620,Jefferson City - MO
 2008,27620,Jefferson City - MO
 2009,27620,Jefferson City - MO
 2010,27620,Jefferson City - MO
 2011,27620,Jefferson City - MO
 2012,27620,Jefferson City - MO
+2013,27620,Jefferson City - MO
 2007,27740,Johnson City - TN
 2008,27740,Johnson City - TN
 2009,27740,Johnson City - TN
 2010,27740,Johnson City - TN
 2011,27740,Johnson City - TN
 2012,27740,Johnson City - TN
+2013,27740,Johnson City - TN
 2007,27780,Johnstown - PA
 2008,27780,Johnstown - PA
 2009,27780,Johnstown - PA
 2010,27780,Johnstown - PA
 2011,27780,Johnstown - PA
 2012,27780,Johnstown - PA
+2013,27780,Johnstown - PA
 2007,27860,Jonesboro - AR
 2008,27860,Jonesboro - AR
 2009,27860,Jonesboro - AR
 2010,27860,Jonesboro - AR
 2011,27860,Jonesboro - AR
 2012,27860,Jonesboro - AR
+2013,27860,Jonesboro - AR
 2007,27900,Joplin - MO
 2008,27900,Joplin - MO
 2009,27900,Joplin - MO
 2010,27900,Joplin - MO
 2011,27900,Joplin - MO
 2012,27900,Joplin - MO
+2013,27900,Joplin - MO
 2007,28020,"Kalamazoo, Portage - MI"
 2008,28020,"Kalamazoo, Portage - MI"
 2009,28020,"Kalamazoo, Portage - MI"
 2010,28020,"Kalamazoo, Portage - MI"
 2011,28020,"Kalamazoo, Portage - MI"
 2012,28020,"Kalamazoo, Portage - MI"
+2013,28020,"Kalamazoo, Portage - MI"
 2007,28100,"Kankakee, Bradley - IL"
 2008,28100,"Kankakee, Bradley - IL"
 2009,28100,"Kankakee, Bradley - IL"
 2010,28100,"Kankakee, Bradley - IL"
 2011,28100,"Kankakee, Bradley - IL"
 2012,28100,"Kankakee, Bradley - IL"
+2013,28100,"Kankakee, Bradley - IL"
 2007,28140,"Kansas City - MO, KS"
 2008,28140,"Kansas City - MO, KS"
 2009,28140,"Kansas City - MO, KS"
 2010,28140,"Kansas City - MO, KS"
 2011,28140,"Kansas City - MO, KS"
 2012,28140,"Kansas City - MO, KS"
+2013,28140,"Kansas City - MO, KS"
+2007,28420,"Kennewick, Richland, Pasco - WA"
 2008,28420,"Kennewick, Pasco, Richland - WA"
 2009,28420,"Kennewick, Pasco, Richland - WA"
 2010,28420,"Kennewick, Pasco, Richland - WA"
 2011,28420,"Kennewick, Pasco, Richland - WA"
 2012,28420,"Kennewick, Pasco, Richland - WA"
-2007,28420,"Kennewick, Richland, Pasco - WA"
+2013,28420,"Kennewick, Pasco, Richland - WA"
 2007,28660,"Killeen, Temple, Fort Hood - TX"
 2008,28660,"Killeen, Temple, Fort Hood - TX"
 2009,28660,"Killeen, Temple, Fort Hood - TX"
 2010,28660,"Killeen, Temple, Fort Hood - TX"
 2011,28660,"Killeen, Temple, Fort Hood - TX"
 2012,28660,"Killeen, Temple, Fort Hood - TX"
+2013,28660,"Killeen, Temple, Fort Hood - TX"
 2007,28700,"Kingsport, Bristol, Bristol - TN, VA"
 2008,28700,"Kingsport, Bristol, Bristol - TN, VA"
 2009,28700,"Kingsport, Bristol, Bristol - TN, VA"
 2010,28700,"Kingsport, Bristol, Bristol - TN, VA"
 2011,28700,"Kingsport, Bristol, Bristol - TN, VA"
 2012,28700,"Kingsport, Bristol, Bristol - TN, VA"
+2013,28700,"Kingsport, Bristol, Bristol - TN, VA"
 2007,28740,Kingston - NY
 2008,28740,Kingston - NY
 2009,28740,Kingston - NY
 2010,28740,Kingston - NY
 2011,28740,Kingston - NY
 2012,28740,Kingston - NY
+2013,28740,Kingston - NY
 2007,28940,Knoxville - TN
 2008,28940,Knoxville - TN
 2009,28940,Knoxville - TN
 2010,28940,Knoxville - TN
 2011,28940,Knoxville - TN
 2012,28940,Knoxville - TN
+2013,28940,Knoxville - TN
 2007,29020,Kokomo - IN
 2008,29020,Kokomo - IN
 2009,29020,Kokomo - IN
 2010,29020,Kokomo - IN
 2011,29020,Kokomo - IN
 2012,29020,Kokomo - IN
+2013,29020,Kokomo - IN
 2007,29100,"La Crosse - WI, MN"
 2008,29100,"La Crosse - WI, MN"
 2009,29100,"La Crosse - WI, MN"
 2010,29100,"La Crosse - WI, MN"
 2011,29100,"La Crosse - WI, MN"
 2012,29100,"La Crosse - WI, MN"
+2013,29100,"La Crosse - WI, MN"
 2007,29140,Lafayette - IN
 2008,29140,Lafayette - IN
 2009,29140,Lafayette - IN
 2010,29140,Lafayette - IN
 2011,29140,Lafayette - IN
 2012,29140,Lafayette - IN
+2013,29140,Lafayette - IN
 2007,29180,Lafayette - LA
 2008,29180,Lafayette - LA
 2009,29180,Lafayette - LA
 2010,29180,Lafayette - LA
 2011,29180,Lafayette - LA
 2012,29180,Lafayette - LA
+2013,29180,Lafayette - LA
 2007,29340,Lake Charles - LA
 2008,29340,Lake Charles - LA
 2009,29340,Lake Charles - LA
 2010,29340,Lake Charles - LA
 2011,29340,Lake Charles - LA
 2012,29340,Lake Charles - LA
+2013,29340,Lake Charles - LA
 2007,29404,"Lake County, Kenosha County - IL, WI"
 2008,29404,"Lake County, Kenosha County - IL, WI"
 2009,29404,"Lake County, Kenosha County - IL, WI"
 2010,29404,"Lake County, Kenosha County - IL, WI"
 2011,29404,"Lake County, Kenosha County - IL, WI"
 2012,29404,"Lake County, Kenosha County - IL, WI"
+2013,29404,"Lake County, Kenosha County - IL, WI"
 2007,29420,"Lake Havasu City, Kingman - AZ"
 2008,29420,"Lake Havasu City, Kingman - AZ"
 2009,29420,"Lake Havasu City, Kingman - AZ"
 2010,29420,"Lake Havasu City, Kingman - AZ"
 2011,29420,"Lake Havasu City, Kingman - AZ"
 2012,29420,"Lake Havasu City, Kingman - AZ"
+2013,29420,"Lake Havasu City, Kingman - AZ"
 2007,29460,Lakeland - FL
 2008,29460,"Lakeland, Winter Haven - FL"
 2009,29460,"Lakeland, Winter Haven - FL"
 2010,29460,"Lakeland, Winter Haven - FL"
 2011,29460,"Lakeland, Winter Haven - FL"
 2012,29460,"Lakeland, Winter Haven - FL"
+2013,29460,"Lakeland, Winter Haven - FL"
 2007,29540,Lancaster - PA
 2008,29540,Lancaster - PA
 2009,29540,Lancaster - PA
 2010,29540,Lancaster - PA
 2011,29540,Lancaster - PA
 2012,29540,Lancaster - PA
+2013,29540,Lancaster - PA
 2007,29620,"Lansing, East Lansing - MI"
 2008,29620,"Lansing, East Lansing - MI"
 2009,29620,"Lansing, East Lansing - MI"
 2010,29620,"Lansing, East Lansing - MI"
 2011,29620,"Lansing, East Lansing - MI"
 2012,29620,"Lansing, East Lansing - MI"
+2013,29620,"Lansing, East Lansing - MI"
 2007,29700,Laredo - TX
 2008,29700,Laredo - TX
 2009,29700,Laredo - TX
 2010,29700,Laredo - TX
 2011,29700,Laredo - TX
 2012,29700,Laredo - TX
+2013,29700,Laredo - TX
 2007,29740,Las Cruces - NM
 2008,29740,Las Cruces - NM
 2009,29740,Las Cruces - NM
 2010,29740,Las Cruces - NM
 2011,29740,Las Cruces - NM
 2012,29740,Las Cruces - NM
+2013,29740,Las Cruces - NM
 2007,29820,"Las Vegas, Paradise - NV"
 2008,29820,"Las Vegas, Paradise - NV"
 2009,29820,"Las Vegas, Paradise - NV"
 2010,29820,"Las Vegas, Paradise - NV"
 2011,29820,"Las Vegas, Paradise - NV"
 2012,29820,"Las Vegas, Paradise - NV"
+2013,29820,"Las Vegas, Paradise - NV"
 2007,29940,Lawrence - KS
 2008,29940,Lawrence - KS
 2009,29940,Lawrence - KS
 2010,29940,Lawrence - KS
 2011,29940,Lawrence - KS
 2012,29940,Lawrence - KS
+2013,29940,Lawrence - KS
 2007,30020,Lawton - OK
 2008,30020,Lawton - OK
 2009,30020,Lawton - OK
 2010,30020,Lawton - OK
 2011,30020,Lawton - OK
 2012,30020,Lawton - OK
+2013,30020,Lawton - OK
 2007,30140,Lebanon - PA
 2008,30140,Lebanon - PA
 2009,30140,Lebanon - PA
 2010,30140,Lebanon - PA
 2011,30140,Lebanon - PA
 2012,30140,Lebanon - PA
+2013,30140,Lebanon - PA
 2007,30300,"Lewiston - ID, WA"
 2008,30300,"Lewiston - ID, WA"
 2009,30300,"Lewiston - ID, WA"
 2010,30300,"Lewiston - ID, WA"
 2011,30300,"Lewiston - ID, WA"
 2012,30300,"Lewiston - ID, WA"
+2013,30300,"Lewiston - ID, WA"
 2007,30340,"Lewiston, Auburn - ME"
 2008,30340,"Lewiston, Auburn - ME"
 2009,30340,"Lewiston, Auburn - ME"
 2010,30340,"Lewiston, Auburn - ME"
 2011,30340,"Lewiston, Auburn - ME"
 2012,30340,"Lewiston, Auburn - ME"
+2013,30340,"Lewiston, Auburn - ME"
 2007,30460,"Lexington, Fayette - KY"
 2008,30460,"Lexington, Fayette - KY"
 2009,30460,"Lexington, Fayette - KY"
 2010,30460,"Lexington, Fayette - KY"
 2011,30460,"Lexington, Fayette - KY"
 2012,30460,"Lexington, Fayette - KY"
+2013,30460,"Lexington, Fayette - KY"
 2007,30620,Lima - OH
 2008,30620,Lima - OH
 2009,30620,Lima - OH
 2010,30620,Lima - OH
 2011,30620,Lima - OH
 2012,30620,Lima - OH
+2013,30620,Lima - OH
 2007,30700,Lincoln - NE
 2008,30700,Lincoln - NE
 2009,30700,Lincoln - NE
 2010,30700,Lincoln - NE
 2011,30700,Lincoln - NE
 2012,30700,Lincoln - NE
+2013,30700,Lincoln - NE
 2007,30780,"Little Rock, North Little Rock, Conway - AR"
 2008,30780,"Little Rock, North Little Rock, Conway - AR"
 2009,30780,"Little Rock, North Little Rock, Conway - AR"
 2010,30780,"Little Rock, North Little Rock, Conway - AR"
 2011,30780,"Little Rock, North Little Rock, Conway - AR"
 2012,30780,"Little Rock, North Little Rock, Conway - AR"
+2013,30780,"Little Rock, North Little Rock, Conway - AR"
 2007,30860,"Logan - UT, ID"
 2008,30860,"Logan - UT, ID"
 2009,30860,"Logan - UT, ID"
 2010,30860,"Logan - UT, ID"
 2011,30860,"Logan - UT, ID"
 2012,30860,"Logan - UT, ID"
+2013,30860,"Logan - UT, ID"
 2007,30980,Longview - TX
 2008,30980,Longview - TX
 2009,30980,Longview - TX
 2010,30980,Longview - TX
 2011,30980,Longview - TX
 2012,30980,Longview - TX
+2013,30980,Longview - TX
 2007,31020,Longview - WA
 2008,31020,Longview - WA
 2009,31020,Longview - WA
 2010,31020,Longview - WA
 2011,31020,Longview - WA
 2012,31020,Longview - WA
+2013,31020,Longview - WA
 2007,31084,"Los Angeles, Long Beach, Glendale - CA"
 2008,31084,"Los Angeles, Long Beach, Glendale - CA"
 2009,31084,"Los Angeles, Long Beach, Glendale - CA"
 2010,31084,"Los Angeles, Long Beach, Glendale - CA"
 2011,31084,"Los Angeles, Long Beach, Glendale - CA"
 2012,31084,"Los Angeles, Long Beach, Glendale - CA"
+2013,31084,"Los Angeles, Long Beach, Glendale - CA"
 2007,31140,"Louisville, Jefferson County - KY, IN"
 2008,31140,"Louisville, Jefferson County - KY, IN"
 2009,31140,"Louisville, Jefferson County - KY, IN"
 2010,31140,"Louisville, Jefferson County - KY, IN"
 2011,31140,"Louisville, Jefferson County - KY, IN"
 2012,31140,"Louisville, Jefferson County - KY, IN"
+2013,31140,"Louisville, Jefferson County - KY, IN"
 2007,31180,Lubbock - TX
 2008,31180,Lubbock - TX
 2009,31180,Lubbock - TX
 2010,31180,Lubbock - TX
 2011,31180,Lubbock - TX
 2012,31180,Lubbock - TX
+2013,31180,Lubbock - TX
 2007,31340,Lynchburg - VA
 2008,31340,Lynchburg - VA
 2009,31340,Lynchburg - VA
 2010,31340,Lynchburg - VA
 2011,31340,Lynchburg - VA
 2012,31340,Lynchburg - VA
+2013,31340,Lynchburg - VA
 2007,31420,Macon - GA
 2008,31420,Macon - GA
 2009,31420,Macon - GA
 2010,31420,Macon - GA
 2011,31420,Macon - GA
 2012,31420,Macon - GA
+2013,31420,Macon - GA
 2007,31460,Madera - CA
 2008,31460,Madera - CA
 2009,31460,"Madera, Chowchilla - CA"
 2010,31460,"Madera, Chowchilla - CA"
 2011,31460,"Madera, Chowchilla - CA"
 2012,31460,"Madera, Chowchilla - CA"
+2013,31460,"Madera, Chowchilla - CA"
 2007,31540,Madison - WI
 2008,31540,Madison - WI
 2009,31540,Madison - WI
 2010,31540,Madison - WI
 2011,31540,Madison - WI
 2012,31540,Madison - WI
+2013,31540,Madison - WI
 2007,31700,"Manchester, Nashua - NH"
 2008,31700,"Manchester, Nashua - NH"
 2009,31700,"Manchester, Nashua - NH"
 2010,31700,"Manchester, Nashua - NH"
 2011,31700,"Manchester, Nashua - NH"
 2012,31700,"Manchester, Nashua - NH"
+2013,31700,"Manchester, Nashua - NH"
 2009,31740,Manhattan - KS
 2010,31740,Manhattan - KS
 2011,31740,Manhattan - KS
 2012,31740,Manhattan - KS
+2013,31740,Manhattan - KS
 2009,31860,"Mankato, North Mankato - MN"
 2010,31860,"Mankato, North Mankato - MN"
 2011,31860,"Mankato, North Mankato - MN"
 2012,31860,"Mankato, North Mankato - MN"
+2013,31860,"Mankato, North Mankato - MN"
 2007,31900,Mansfield - OH
 2008,31900,Mansfield - OH
 2009,31900,Mansfield - OH
 2010,31900,Mansfield - OH
 2011,31900,Mansfield - OH
 2012,31900,Mansfield - OH
+2013,31900,Mansfield - OH
 2007,32420,Mayaguez - PR
 2008,32420,Mayaguez - PR
 2009,32420,Mayaguez - PR
 2010,32420,Mayaguez - PR
 2011,32420,Mayaguez - PR
 2012,32420,Mayaguez - PR
+2013,32420,Mayaguez - PR
 2007,32580,"McAllen, Edinburg, Mission - TX"
 2008,32580,"McAllen, Edinburg, Mission - TX"
 2009,32580,"McAllen, Edinburg, Mission - TX"
 2010,32580,"McAllen, Edinburg, Mission - TX"
 2011,32580,"McAllen, Edinburg, Mission - TX"
 2012,32580,"McAllen, Edinburg, Mission - TX"
+2013,32580,"McAllen, Edinburg, Mission - TX"
 2007,32780,Medford - OR
 2008,32780,Medford - OR
 2009,32780,Medford - OR
 2010,32780,Medford - OR
 2011,32780,Medford - OR
 2012,32780,Medford - OR
+2013,32780,Medford - OR
 2007,32820,"Memphis - TN, MS, AR"
 2008,32820,"Memphis - TN, MS, AR"
 2009,32820,"Memphis - TN, MS, AR"
 2010,32820,"Memphis - TN, MS, AR"
 2011,32820,"Memphis - TN, MS, AR"
 2012,32820,"Memphis - TN, MS, AR"
+2013,32820,"Memphis - TN, MS, AR"
 2007,32900,Merced - CA
 2008,32900,Merced - CA
 2009,32900,Merced - CA
 2010,32900,Merced - CA
 2011,32900,Merced - CA
 2012,32900,Merced - CA
+2013,32900,Merced - CA
 2007,33124,"Miami, Miami Beach, Kendall - FL"
 2008,33124,"Miami, Miami Beach, Kendall - FL"
 2009,33124,"Miami, Miami Beach, Kendall - FL"
 2010,33124,"Miami, Miami Beach, Kendall - FL"
 2011,33124,"Miami, Miami Beach, Kendall - FL"
 2012,33124,"Miami, Miami Beach, Kendall - FL"
+2013,33124,"Miami, Miami Beach, Kendall - FL"
 2007,33140,"Michigan City, La Porte - IN"
 2008,33140,"Michigan City, La Porte - IN"
 2009,33140,"Michigan City, La Porte - IN"
 2010,33140,"Michigan City, La Porte - IN"
 2011,33140,"Michigan City, La Porte - IN"
 2012,33140,"Michigan City, La Porte - IN"
+2013,33140,"Michigan City, La Porte - IN"
 2007,33260,Midland - TX
 2008,33260,Midland - TX
 2009,33260,Midland - TX
 2010,33260,Midland - TX
 2011,33260,Midland - TX
 2012,33260,Midland - TX
+2013,33260,Midland - TX
 2007,33340,"Milwaukee, Waukesha, West Allis - WI"
 2008,33340,"Milwaukee, Waukesha, West Allis - WI"
 2009,33340,"Milwaukee, Waukesha, West Allis - WI"
 2010,33340,"Milwaukee, Waukesha, West Allis - WI"
 2011,33340,"Milwaukee, Waukesha, West Allis - WI"
 2012,33340,"Milwaukee, Waukesha, West Allis - WI"
+2013,33340,"Milwaukee, Waukesha, West Allis - WI"
 2007,33460,"Minneapolis, St. Paul, Bloomington - MN, WI"
 2008,33460,"Minneapolis, St. Paul, Bloomington - MN, WI"
 2009,33460,"Minneapolis, St. Paul, Bloomington - MN, WI"
 2010,33460,"Minneapolis, St. Paul, Bloomington - MN, WI"
 2011,33460,"Minneapolis, St. Paul, Bloomington - MN, WI"
 2012,33460,"Minneapolis, St. Paul, Bloomington - MN, WI"
+2013,33460,"Minneapolis, St. Paul, Bloomington - MN, WI"
 2007,33540,Missoula - MT
 2008,33540,Missoula - MT
 2009,33540,Missoula - MT
 2010,33540,Missoula - MT
 2011,33540,Missoula - MT
 2012,33540,Missoula - MT
+2013,33540,Missoula - MT
 2007,33660,Mobile - AL
 2008,33660,Mobile - AL
 2009,33660,Mobile - AL
 2010,33660,Mobile - AL
 2011,33660,Mobile - AL
 2012,33660,Mobile - AL
+2013,33660,Mobile - AL
 2007,33700,Modesto - CA
 2008,33700,Modesto - CA
 2009,33700,Modesto - CA
 2010,33700,Modesto - CA
 2011,33700,Modesto - CA
 2012,33700,Modesto - CA
+2013,33700,Modesto - CA
 2007,33740,Monroe - LA
 2008,33740,Monroe - LA
 2009,33740,Monroe - LA
 2010,33740,Monroe - LA
 2011,33740,Monroe - LA
 2012,33740,Monroe - LA
+2013,33740,Monroe - LA
 2007,33780,Monroe - MI
 2008,33780,Monroe - MI
 2009,33780,Monroe - MI
 2010,33780,Monroe - MI
 2011,33780,Monroe - MI
 2012,33780,Monroe - MI
+2013,33780,Monroe - MI
 2007,33860,Montgomery - AL
 2008,33860,Montgomery - AL
 2009,33860,Montgomery - AL
 2010,33860,Montgomery - AL
 2011,33860,Montgomery - AL
 2012,33860,Montgomery - AL
+2013,33860,Montgomery - AL
 2007,34060,Morgantown - WV
 2008,34060,Morgantown - WV
 2009,34060,Morgantown - WV
 2010,34060,Morgantown - WV
 2011,34060,Morgantown - WV
 2012,34060,Morgantown - WV
+2013,34060,Morgantown - WV
 2007,34100,Morristown - TN
 2008,34100,Morristown - TN
 2009,34100,Morristown - TN
 2010,34100,Morristown - TN
 2011,34100,Morristown - TN
 2012,34100,Morristown - TN
+2013,34100,Morristown - TN
 2007,34580,"Mount Vernon, Anacortes - WA"
 2008,34580,"Mount Vernon, Anacortes - WA"
 2009,34580,"Mount Vernon, Anacortes - WA"
 2010,34580,"Mount Vernon, Anacortes - WA"
 2011,34580,"Mount Vernon, Anacortes - WA"
 2012,34580,"Mount Vernon, Anacortes - WA"
+2013,34580,"Mount Vernon, Anacortes - WA"
 2007,34620,Muncie - IN
 2008,34620,Muncie - IN
 2009,34620,Muncie - IN
 2010,34620,Muncie - IN
 2011,34620,Muncie - IN
 2012,34620,Muncie - IN
+2013,34620,Muncie - IN
 2007,34740,"Muskegon, Norton Shores - MI"
 2008,34740,"Muskegon, Norton Shores - MI"
 2009,34740,"Muskegon, Norton Shores - MI"
 2010,34740,"Muskegon, Norton Shores - MI"
 2011,34740,"Muskegon, Norton Shores - MI"
 2012,34740,"Muskegon, Norton Shores - MI"
+2013,34740,"Muskegon, Norton Shores - MI"
 2007,34820,"Myrtle Beach, Conway, North Myrtle Beach - SC"
 2008,34820,"Myrtle Beach, North Myrtle Beach, Conway - SC"
 2009,34820,"Myrtle Beach, North Myrtle Beach, Conway - SC"
 2010,34820,"Myrtle Beach, North Myrtle Beach, Conway - SC"
 2011,34820,"Myrtle Beach, North Myrtle Beach, Conway - SC"
 2012,34820,"Myrtle Beach, North Myrtle Beach, Conway - SC"
-2007,99999,NA (Outside of MSA/MD)
-2008,99999,NA (Outside of MSA/MD)
-2009,99999,NA (Outside of MSA/MD)
-2010,99999,NA (Outside of MSA/MD)
-2011,99999,NA (Outside of MSA/MD)
-2012,99999,NA (Outside of MSA/MD)
+2013,34820,"Myrtle Beach, North Myrtle Beach, Conway - SC"
 2007,34900,Napa - CA
 2008,34900,Napa - CA
 2009,34900,Napa - CA
 2010,34900,Napa - CA
 2011,34900,Napa - CA
 2012,34900,Napa - CA
+2013,34900,Napa - CA
 2007,34940,"Naples, Marco Island - FL"
 2008,34940,"Naples, Marco Island - FL"
 2009,34940,"Naples, Marco Island - FL"
 2010,34940,"Naples, Marco Island - FL"
 2011,34940,"Naples, Marco Island - FL"
 2012,34940,"Naples, Marco Island - FL"
+2013,34940,"Naples, Marco Island - FL"
 2007,34980,"Nashville, Davidson, Murfreesboro, Franklin - TN"
 2008,34980,"Nashville, Davidson, Murfreesboro, Franklin - TN"
 2009,34980,"Nashville, Davidson, Murfreesboro, Franklin - TN"
 2010,34980,"Nashville, Davidson, Murfreesboro, Franklin - TN"
 2011,34980,"Nashville, Davidson, Murfreesboro, Franklin - TN"
 2012,34980,"Nashville, Davidson, Murfreesboro, Franklin - TN"
+2013,34980,"Nashville, Davidson, Murfreesboro, Franklin - TN"
 2007,35004,"Nassau, Suffolk - NY"
 2008,35004,"Nassau, Suffolk - NY"
 2009,35004,"Nassau, Suffolk - NY"
 2010,35004,"Nassau, Suffolk - NY"
 2011,35004,"Nassau, Suffolk - NY"
 2012,35004,"Nassau, Suffolk - NY"
-2007,35300,"New Haven, Milford - CT"
-2008,35300,"New Haven, Milford - CT"
-2009,35300,"New Haven, Milford - CT"
-2010,35300,"New Haven, Milford - CT"
-2011,35300,"New Haven, Milford - CT"
-2012,35300,"New Haven, Milford - CT"
-2007,35380,"New Orleans, Metairie, Kenner - LA"
-2008,35380,"New Orleans, Metairie, Kenner - LA"
-2009,35380,"New Orleans, Metairie, Kenner - LA"
-2010,35380,"New Orleans, Metairie, Kenner - LA"
-2011,35380,"New Orleans, Metairie, Kenner - LA"
-2012,35380,"New Orleans, Metairie, Kenner - LA"
-2007,35644,"New York, White Plains, Wayne - NY, NJ"
-2008,35644,"New York, White Plains, Wayne - NY, NJ"
-2009,35644,"New York, White Plains, Wayne - NY, NJ"
-2010,35644,"New York, White Plains, Wayne - NY, NJ"
-2011,35644,"New York, White Plains, Wayne - NY, NJ"
-2012,35644,"New York, White Plains, Wayne - NY, NJ"
+2013,35004,"Nassau, Suffolk - NY"
 2007,35084,"Newark, Union - NJ, PA"
 2008,35084,"Newark, Union - NJ, PA"
 2009,35084,"Newark, Union - NJ, PA"
 2010,35084,"Newark, Union - NJ, PA"
 2011,35084,"Newark, Union - NJ, PA"
 2012,35084,"Newark, Union - NJ, PA"
+2013,35084,"Newark, Union - NJ, PA"
+2007,35300,"New Haven, Milford - CT"
+2008,35300,"New Haven, Milford - CT"
+2009,35300,"New Haven, Milford - CT"
+2010,35300,"New Haven, Milford - CT"
+2011,35300,"New Haven, Milford - CT"
+2012,35300,"New Haven, Milford - CT"
+2013,35300,"New Haven, Milford - CT"
+2007,35380,"New Orleans, Metairie, Kenner - LA"
+2008,35380,"New Orleans, Metairie, Kenner - LA"
+2009,35380,"New Orleans, Metairie, Kenner - LA"
+2010,35380,"New Orleans, Metairie, Kenner - LA"
+2011,35380,"New Orleans, Metairie, Kenner - LA"
+2012,35380,"New Orleans, Metairie, Kenner - LA"
+2013,35380,"New Orleans, Metairie, Kenner - LA"
+2007,35644,"New York, White Plains, Wayne - NY, NJ"
+2008,35644,"New York, White Plains, Wayne - NY, NJ"
+2009,35644,"New York, White Plains, Wayne - NY, NJ"
+2010,35644,"New York, White Plains, Wayne - NY, NJ"
+2011,35644,"New York, White Plains, Wayne - NY, NJ"
+2012,35644,"New York, White Plains, Wayne - NY, NJ"
+2013,35644,"New York, White Plains, Wayne - NY, NJ"
 2007,35660,"Niles, Benton Harbor - MI"
 2008,35660,"Niles, Benton Harbor - MI"
 2009,35660,"Niles, Benton Harbor - MI"
 2010,35660,"Niles, Benton Harbor - MI"
 2011,35660,"Niles, Benton Harbor - MI"
 2012,35660,"Niles, Benton Harbor - MI"
+2013,35660,"Niles, Benton Harbor - MI"
 2010,35840,"North Port, Bradenton, Sarasota - FL"
 2011,35840,"North Port, Bradenton, Sarasota - FL"
 2012,35840,"North Port, Bradenton, Sarasota - FL"
+2013,35840,"North Port, Bradenton, Sarasota - FL"
 2007,35980,"Norwich, New London - CT"
 2008,35980,"Norwich, New London - CT"
 2009,35980,"Norwich, New London - CT"
 2010,35980,"Norwich, New London - CT"
 2011,35980,"Norwich, New London - CT"
 2012,35980,"Norwich, New London - CT"
+2013,35980,"Norwich, New London - CT"
 2007,36084,"Oakland, Fremont, Hayward - CA"
 2008,36084,"Oakland, Fremont, Hayward - CA"
 2009,36084,"Oakland, Fremont, Hayward - CA"
 2010,36084,"Oakland, Fremont, Hayward - CA"
 2011,36084,"Oakland, Fremont, Hayward - CA"
 2012,36084,"Oakland, Fremont, Hayward - CA"
+2013,36084,"Oakland, Fremont, Hayward - CA"
 2007,36100,Ocala - FL
 2008,36100,Ocala - FL
 2009,36100,Ocala - FL
 2010,36100,Ocala - FL
 2011,36100,Ocala - FL
 2012,36100,Ocala - FL
+2013,36100,Ocala - FL
 2007,36140,Ocean City - NJ
 2008,36140,Ocean City - NJ
 2009,36140,Ocean City - NJ
 2010,36140,Ocean City - NJ
 2011,36140,Ocean City - NJ
 2012,36140,Ocean City - NJ
+2013,36140,Ocean City - NJ
 2007,36220,Odessa - TX
 2008,36220,Odessa - TX
 2009,36220,Odessa - TX
 2010,36220,Odessa - TX
 2011,36220,Odessa - TX
 2012,36220,Odessa - TX
+2013,36220,Odessa - TX
 2007,36260,"Ogden, Clearfield - UT"
 2008,36260,"Ogden, Clearfield - UT"
 2009,36260,"Ogden, Clearfield - UT"
 2010,36260,"Ogden, Clearfield - UT"
 2011,36260,"Ogden, Clearfield - UT"
 2012,36260,"Ogden, Clearfield - UT"
+2013,36260,"Ogden, Clearfield - UT"
 2007,36420,Oklahoma City - OK
 2008,36420,Oklahoma City - OK
 2009,36420,Oklahoma City - OK
 2010,36420,Oklahoma City - OK
 2011,36420,Oklahoma City - OK
 2012,36420,Oklahoma City - OK
+2013,36420,Oklahoma City - OK
 2007,36500,Olympia - WA
 2008,36500,Olympia - WA
 2009,36500,Olympia - WA
 2010,36500,Olympia - WA
 2011,36500,Olympia - WA
 2012,36500,Olympia - WA
+2013,36500,Olympia - WA
 2007,36540,"Omaha, Council Bluffs - NE, IA"
 2008,36540,"Omaha, Council Bluffs - NE, IA"
 2009,36540,"Omaha, Council Bluffs - NE, IA"
 2010,36540,"Omaha, Council Bluffs - NE, IA"
 2011,36540,"Omaha, Council Bluffs - NE, IA"
 2012,36540,"Omaha, Council Bluffs - NE, IA"
+2013,36540,"Omaha, Council Bluffs - NE, IA"
 2007,36740,"Orlando, Kissimmee - FL"
 2008,36740,"Orlando, Kissimmee - FL"
 2009,36740,"Orlando, Kissimmee - FL"
 2010,36740,"Orlando, Kissimmee, Sanford - FL"
 2011,36740,"Orlando, Kissimmee, Sanford - FL"
 2012,36740,"Orlando, Kissimmee, Sanford - FL"
+2013,36740,"Orlando, Kissimmee, Sanford - FL"
 2007,36780,"Oshkosh, Neenah - WI"
 2008,36780,"Oshkosh, Neenah - WI"
 2009,36780,"Oshkosh, Neenah - WI"
 2010,36780,"Oshkosh, Neenah - WI"
 2011,36780,"Oshkosh, Neenah - WI"
 2012,36780,"Oshkosh, Neenah - WI"
+2013,36780,"Oshkosh, Neenah - WI"
 2007,36980,Owensboro - KY
 2008,36980,Owensboro - KY
 2009,36980,Owensboro - KY
 2010,36980,Owensboro - KY
 2011,36980,Owensboro - KY
 2012,36980,Owensboro - KY
+2013,36980,Owensboro - KY
 2007,37100,"Oxnard, Thousand Oaks, Ventura - CA"
 2008,37100,"Oxnard, Thousand Oaks, Ventura - CA"
 2009,37100,"Oxnard, Thousand Oaks, Ventura - CA"
 2010,37100,"Oxnard, Thousand Oaks, Ventura - CA"
 2011,37100,"Oxnard, Thousand Oaks, Ventura - CA"
 2012,37100,"Oxnard, Thousand Oaks, Ventura - CA"
+2013,37100,"Oxnard, Thousand Oaks, Ventura - CA"
 2007,37340,"Palm Bay, Melbourne, Titusville - FL"
 2008,37340,"Palm Bay, Melbourne, Titusville - FL"
 2009,37340,"Palm Bay, Melbourne, Titusville - FL"
 2010,37340,"Palm Bay, Melbourne, Titusville - FL"
 2011,37340,"Palm Bay, Melbourne, Titusville - FL"
 2012,37340,"Palm Bay, Melbourne, Titusville - FL"
+2013,37340,"Palm Bay, Melbourne, Titusville - FL"
 2007,37380,Palm Coast - FL
 2008,37380,Palm Coast - FL
 2009,37380,Palm Coast - FL
 2010,37380,Palm Coast - FL
 2011,37380,Palm Coast - FL
 2012,37380,Palm Coast - FL
+2013,37380,Palm Coast - FL
 2007,37460,"Panama City, Lynn Haven - FL"
 2008,37460,"Panama City, Lynn Haven - FL"
 2009,37460,"Panama City, Lynn Haven, Panama City Beach - FL"
 2010,37460,"Panama City, Lynn Haven, Panama City Beach - FL"
 2011,37460,"Panama City, Lynn Haven, Panama City Beach - FL"
 2012,37460,"Panama City, Lynn Haven, Panama City Beach - FL"
+2013,37460,"Panama City, Lynn Haven, Panama City Beach - FL"
 2007,37620,"Parkersburg, Marietta, Vienna - WV, OH"
 2008,37620,"Parkersburg, Marietta, Vienna - WV, OH"
 2009,37620,"Parkersburg, Marietta, Vienna - WV, OH"
 2010,37620,"Parkersburg, Marietta, Vienna - WV, OH"
 2011,37620,"Parkersburg, Marietta, Vienna - WV, OH"
 2012,37620,"Parkersburg, Marietta, Vienna - WV, OH"
+2013,37620,"Parkersburg, Marietta, Vienna - WV, OH"
 2007,37700,Pascagoula - MS
 2008,37700,Pascagoula - MS
 2009,37700,Pascagoula - MS
 2010,37700,Pascagoula - MS
 2011,37700,Pascagoula - MS
 2012,37700,Pascagoula - MS
+2013,37700,Pascagoula - MS
 2007,37764,Peabody - MA
 2008,37764,Peabody - MA
 2009,37764,Peabody - MA
 2010,37764,Peabody - MA
 2011,37764,Peabody - MA
 2012,37764,Peabody - MA
+2013,37764,Peabody - MA
 2007,37860,"Pensacola, Ferry Pass, Brent - FL"
 2008,37860,"Pensacola, Ferry Pass, Brent - FL"
 2009,37860,"Pensacola, Ferry Pass, Brent - FL"
 2010,37860,"Pensacola, Ferry Pass, Brent - FL"
 2011,37860,"Pensacola, Ferry Pass, Brent - FL"
 2012,37860,"Pensacola, Ferry Pass, Brent - FL"
+2013,37860,"Pensacola, Ferry Pass, Brent - FL"
 2007,37900,Peoria - IL
 2008,37900,Peoria - IL
 2009,37900,Peoria - IL
 2010,37900,Peoria - IL
 2011,37900,Peoria - IL
 2012,37900,Peoria - IL
+2013,37900,Peoria - IL
 2007,37964,Philadelphia - PA
 2008,37964,Philadelphia - PA
 2009,37964,Philadelphia - PA
 2010,37964,Philadelphia - PA
 2011,37964,Philadelphia - PA
 2012,37964,Philadelphia - PA
-2010,38060,"Phoenix, Mesa, Glendale - AZ"
-2011,38060,"Phoenix, Mesa, Glendale - AZ"
-2012,38060,"Phoenix, Mesa, Glendale - AZ"
+2013,37964,Philadelphia - PA
 2007,38060,"Phoenix, Mesa, Scottsdale - AZ"
 2008,38060,"Phoenix, Mesa, Scottsdale - AZ"
 2009,38060,"Phoenix, Mesa, Scottsdale - AZ"
+2010,38060,"Phoenix, Mesa, Glendale - AZ"
+2011,38060,"Phoenix, Mesa, Glendale - AZ"
+2012,38060,"Phoenix, Mesa, Glendale - AZ"
+2013,38060,"Phoenix, Mesa, Glendale - AZ"
 2007,38220,Pine Bluff - AR
 2008,38220,Pine Bluff - AR
 2009,38220,Pine Bluff - AR
 2010,38220,Pine Bluff - AR
 2011,38220,Pine Bluff - AR
 2012,38220,Pine Bluff - AR
+2013,38220,Pine Bluff - AR
 2007,38300,Pittsburgh - PA
 2008,38300,Pittsburgh - PA
 2009,38300,Pittsburgh - PA
 2010,38300,Pittsburgh - PA
 2011,38300,Pittsburgh - PA
 2012,38300,Pittsburgh - PA
+2013,38300,Pittsburgh - PA
 2007,38340,Pittsfield - MA
 2008,38340,Pittsfield - MA
 2009,38340,Pittsfield - MA
 2010,38340,Pittsfield - MA
 2011,38340,Pittsfield - MA
 2012,38340,Pittsfield - MA
+2013,38340,Pittsfield - MA
 2007,38540,Pocatello - ID
 2008,38540,Pocatello - ID
 2009,38540,Pocatello - ID
 2010,38540,Pocatello - ID
 2011,38540,Pocatello - ID
 2012,38540,Pocatello - ID
+2013,38540,Pocatello - ID
 2007,38660,Ponce - PR
 2008,38660,Ponce - PR
 2009,38660,Ponce - PR
 2010,38660,Ponce - PR
 2011,38660,Ponce - PR
 2012,38660,Ponce - PR
-2007,38940,Port St. Lucie - FL
-2008,38940,Port St. Lucie - FL
-2009,38940,Port St. Lucie - FL
-2010,38940,Port St. Lucie - FL
-2011,38940,Port St. Lucie - FL
-2012,38940,Port St. Lucie - FL
+2013,38660,Ponce - PR
 2007,38860,"Portland, South Portland, Biddeford - ME"
 2008,38860,"Portland, South Portland, Biddeford - ME"
 2009,38860,"Portland, South Portland, Biddeford - ME"
 2010,38860,"Portland, South Portland, Biddeford - ME"
 2011,38860,"Portland, South Portland, Biddeford - ME"
 2012,38860,"Portland, South Portland, Biddeford - ME"
+2013,38860,"Portland, South Portland, Biddeford - ME"
 2007,38900,"Portland, Vancouver, Beaverton - OR, WA"
 2008,38900,"Portland, Vancouver, Beaverton - OR, WA"
 2009,38900,"Portland, Vancouver, Beaverton - OR, WA"
 2010,38900,"Portland, Vancouver, Hillsboro - OR, WA"
 2011,38900,"Portland, Vancouver, Hillsboro - OR, WA"
 2012,38900,"Portland, Vancouver, Hillsboro - OR, WA"
+2013,38900,"Portland, Vancouver, Hillsboro - OR, WA"
+2007,38940,Port St. Lucie - FL
+2008,38940,Port St. Lucie - FL
+2009,38940,Port St. Lucie - FL
+2010,38940,Port St. Lucie - FL
+2011,38940,Port St. Lucie - FL
+2012,38940,Port St. Lucie - FL
+2013,38940,Port St. Lucie - FL
 2007,39100,"Poughkeepsie, Newburgh, Middletown - NY"
 2008,39100,"Poughkeepsie, Newburgh, Middletown - NY"
 2009,39100,"Poughkeepsie, Newburgh, Middletown - NY"
 2010,39100,"Poughkeepsie, Newburgh, Middletown - NY"
 2011,39100,"Poughkeepsie, Newburgh, Middletown - NY"
 2012,39100,"Poughkeepsie, Newburgh, Middletown - NY"
+2013,39100,"Poughkeepsie, Newburgh, Middletown - NY"
 2007,39140,Prescott - AZ
 2008,39140,Prescott - AZ
 2009,39140,Prescott - AZ
 2010,39140,Prescott - AZ
 2011,39140,Prescott - AZ
 2012,39140,Prescott - AZ
+2013,39140,Prescott - AZ
 2007,39300,"Providence, New Bedford, Fall River - RI, MA"
 2008,39300,"Providence, New Bedford, Fall River - RI, MA"
 2009,39300,"Providence, New Bedford, Fall River - RI, MA"
 2010,39300,"Providence, New Bedford, Fall River - RI, MA"
 2011,39300,"Providence, New Bedford, Fall River - RI, MA"
 2012,39300,"Providence, New Bedford, Fall River - RI, MA"
+2013,39300,"Providence, New Bedford, Fall River - RI, MA"
 2007,39340,"Provo, Orem - UT"
 2008,39340,"Provo, Orem - UT"
 2009,39340,"Provo, Orem - UT"
 2010,39340,"Provo, Orem - UT"
 2011,39340,"Provo, Orem - UT"
 2012,39340,"Provo, Orem - UT"
+2013,39340,"Provo, Orem - UT"
 2007,39380,Pueblo - CO
 2008,39380,Pueblo - CO
 2009,39380,Pueblo - CO
 2010,39380,Pueblo - CO
 2011,39380,Pueblo - CO
 2012,39380,Pueblo - CO
+2013,39380,Pueblo - CO
 2007,39460,Punta Gorda - FL
 2008,39460,Punta Gorda - FL
 2009,39460,Punta Gorda - FL
 2010,39460,Punta Gorda - FL
 2011,39460,Punta Gorda - FL
 2012,39460,Punta Gorda - FL
+2013,39460,Punta Gorda - FL
 2007,39540,Racine - WI
 2008,39540,Racine - WI
 2009,39540,Racine - WI
 2010,39540,Racine - WI
 2011,39540,Racine - WI
 2012,39540,Racine - WI
+2013,39540,Racine - WI
 2007,39580,"Raleigh, Cary - NC"
 2008,39580,"Raleigh, Cary - NC"
 2009,39580,"Raleigh, Cary - NC"
 2010,39580,"Raleigh, Cary - NC"
 2011,39580,"Raleigh, Cary - NC"
 2012,39580,"Raleigh, Cary - NC"
+2013,39580,"Raleigh, Cary - NC"
 2007,39660,Rapid City - SD
 2008,39660,Rapid City - SD
 2009,39660,Rapid City - SD
 2010,39660,Rapid City - SD
 2011,39660,Rapid City - SD
 2012,39660,Rapid City - SD
+2013,39660,Rapid City - SD
 2007,39740,Reading - PA
 2008,39740,Reading - PA
 2009,39740,Reading - PA
 2010,39740,Reading - PA
 2011,39740,Reading - PA
 2012,39740,Reading - PA
+2013,39740,Reading - PA
 2007,39820,Redding - CA
 2008,39820,Redding - CA
 2009,39820,Redding - CA
 2010,39820,Redding - CA
 2011,39820,Redding - CA
 2012,39820,Redding - CA
+2013,39820,Redding - CA
 2007,39900,"Reno, Sparks - NV"
 2008,39900,"Reno, Sparks - NV"
 2009,39900,"Reno, Sparks - NV"
 2010,39900,"Reno, Sparks - NV"
 2011,39900,"Reno, Sparks - NV"
 2012,39900,"Reno, Sparks - NV"
+2013,39900,"Reno, Sparks - NV"
 2007,40060,Richmond - VA
 2008,40060,Richmond - VA
 2009,40060,Richmond - VA
 2010,40060,Richmond - VA
 2011,40060,Richmond - VA
 2012,40060,Richmond - VA
+2013,40060,Richmond - VA
 2007,40140,"Riverside, San Bernardino, Ontario - CA"
 2008,40140,"Riverside, San Bernardino, Ontario - CA"
 2009,40140,"Riverside, San Bernardino, Ontario - CA"
 2010,40140,"Riverside, San Bernardino, Ontario - CA"
 2011,40140,"Riverside, San Bernardino, Ontario - CA"
 2012,40140,"Riverside, San Bernardino, Ontario - CA"
+2013,40140,"Riverside, San Bernardino, Ontario - CA"
 2007,40220,Roanoke - VA
 2008,40220,Roanoke - VA
 2009,40220,Roanoke - VA
 2010,40220,Roanoke - VA
 2011,40220,Roanoke - VA
 2012,40220,Roanoke - VA
+2013,40220,Roanoke - VA
 2007,40340,Rochester - MN
 2008,40340,Rochester - MN
 2009,40340,Rochester - MN
 2010,40340,Rochester - MN
 2011,40340,Rochester - MN
 2012,40340,Rochester - MN
+2013,40340,Rochester - MN
 2007,40380,Rochester - NY
 2008,40380,Rochester - NY
 2009,40380,Rochester - NY
 2010,40380,Rochester - NY
 2011,40380,Rochester - NY
 2012,40380,Rochester - NY
+2013,40380,Rochester - NY
 2007,40420,Rockford - IL
 2008,40420,Rockford - IL
 2009,40420,Rockford - IL
 2010,40420,Rockford - IL
 2011,40420,Rockford - IL
 2012,40420,Rockford - IL
+2013,40420,Rockford - IL
 2007,40484,"Rockingham County, Strafford County - NH"
 2008,40484,"Rockingham County, Strafford County - NH"
 2009,40484,"Rockingham County, Strafford County - NH"
 2010,40484,"Rockingham County, Strafford County - NH"
 2011,40484,"Rockingham County, Strafford County - NH"
 2012,40484,"Rockingham County, Strafford County - NH"
+2013,40484,"Rockingham County, Strafford County - NH"
 2007,40580,Rocky Mount - NC
 2008,40580,Rocky Mount - NC
 2009,40580,Rocky Mount - NC
 2010,40580,Rocky Mount - NC
 2011,40580,Rocky Mount - NC
 2012,40580,Rocky Mount - NC
+2013,40580,Rocky Mount - NC
 2007,40660,Rome - GA
 2008,40660,Rome - GA
 2009,40660,Rome - GA
 2010,40660,Rome - GA
 2011,40660,Rome - GA
 2012,40660,Rome - GA
+2013,40660,Rome - GA
 2007,40900,"Sacramento, Arden, Arcade, Roseville - CA"
 2008,40900,"Sacramento, Arden, Arcade, Roseville - CA"
 2009,40900,"Sacramento, Arden, Arcade, Roseville - CA"
 2010,40900,"Sacramento, Arden, Arcade, Roseville - CA"
 2011,40900,"Sacramento, Arden, Arcade, Roseville - CA"
 2012,40900,"Sacramento, Arden, Arcade, Roseville - CA"
+2013,40900,"Sacramento, Arden, Arcade, Roseville - CA"
 2007,40980,"Saginaw, Saginaw Township North - MI"
 2008,40980,"Saginaw, Saginaw Township North - MI"
 2009,40980,"Saginaw, Saginaw Township North - MI"
 2010,40980,"Saginaw, Saginaw Township North - MI"
 2011,40980,"Saginaw, Saginaw Township North - MI"
 2012,40980,"Saginaw, Saginaw Township North - MI"
+2013,40980,"Saginaw, Saginaw Township North - MI"
+2007,41060,St. Cloud - MN
+2008,41060,St. Cloud - MN
+2009,41060,St. Cloud - MN
+2010,41060,St. Cloud - MN
+2011,41060,St. Cloud - MN
+2012,41060,St. Cloud - MN
+2013,41060,St. Cloud - MN
+2007,41100,St. George - UT
+2008,41100,St. George - UT
+2009,41100,St. George - UT
+2010,41100,St. George - UT
+2011,41100,St. George - UT
+2012,41100,St. George - UT
+2013,41100,St. George - UT
+2007,41140,"St. Joseph - MO, KS"
+2008,41140,"St. Joseph - MO, KS"
+2009,41140,"St. Joseph - MO, KS"
+2010,41140,"St. Joseph - MO, KS"
+2011,41140,"St. Joseph - MO, KS"
+2012,41140,"St. Joseph - MO, KS"
+2013,41140,"St. Joseph - MO, KS"
+2007,41180,"St. Louis - MO, IL"
+2008,41180,"St. Louis - MO, IL"
+2009,41180,"St. Louis - MO, IL"
+2010,41180,"St. Louis - MO, IL"
+2011,41180,"St. Louis - MO, IL"
+2012,41180,"St. Louis - MO, IL"
+2013,41180,"St. Louis - MO, IL"
 2007,41420,Salem - OR
 2008,41420,Salem - OR
 2009,41420,Salem - OR
 2010,41420,Salem - OR
 2011,41420,Salem - OR
 2012,41420,Salem - OR
+2013,41420,Salem - OR
 2007,41500,Salinas - CA
 2008,41500,Salinas - CA
 2009,41500,Salinas - CA
 2010,41500,Salinas - CA
 2011,41500,Salinas - CA
 2012,41500,Salinas - CA
+2013,41500,Salinas - CA
 2007,41540,Salisbury - MD
 2008,41540,Salisbury - MD
 2009,41540,Salisbury - MD
 2010,41540,Salisbury - MD
 2011,41540,Salisbury - MD
 2012,41540,Salisbury - MD
+2013,41540,Salisbury - MD
 2007,41620,Salt Lake City - UT
 2008,41620,Salt Lake City - UT
 2009,41620,Salt Lake City - UT
 2010,41620,Salt Lake City - UT
 2011,41620,Salt Lake City - UT
 2012,41620,Salt Lake City - UT
+2013,41620,Salt Lake City - UT
 2007,41660,San Angelo - TX
 2008,41660,San Angelo - TX
 2009,41660,San Angelo - TX
 2010,41660,San Angelo - TX
 2011,41660,San Angelo - TX
 2012,41660,San Angelo - TX
+2013,41660,San Angelo - TX
 2007,41700,San Antonio - TX
 2008,41700,San Antonio - TX
 2009,41700,San Antonio - TX
 2010,41700,"San Antonio, New Braunfels - TX"
 2011,41700,"San Antonio, New Braunfels - TX"
 2012,41700,"San Antonio, New Braunfels - TX"
+2013,41700,"San Antonio, New Braunfels - TX"
 2007,41740,"San Diego, Carlsbad, San Marcos - CA"
 2008,41740,"San Diego, Carlsbad, San Marcos - CA"
 2009,41740,"San Diego, Carlsbad, San Marcos - CA"
 2010,41740,"San Diego, Carlsbad, San Marcos - CA"
 2011,41740,"San Diego, Carlsbad, San Marcos - CA"
 2012,41740,"San Diego, Carlsbad, San Marcos - CA"
-2007,41884,"San Francisco, San Mateo, Redwood City - CA"
-2008,41884,"San Francisco, San Mateo, Redwood City - CA"
-2009,41884,"San Francisco, San Mateo, Redwood City - CA"
-2010,41884,"San Francisco, San Mateo, Redwood City - CA"
-2011,41884,"San Francisco, San Mateo, Redwood City - CA"
-2012,41884,"San Francisco, San Mateo, Redwood City - CA"
-2007,41900,"San German, Cabo Rojo - PR"
-2008,41900,"San German, Cabo Rojo - PR"
-2009,41900,"San German, Cabo Rojo - PR"
-2010,41900,"San German, Cabo Rojo - PR"
-2011,41900,"San German, Cabo Rojo - PR"
-2012,41900,"San German, Cabo Rojo - PR"
-2007,41940,"San Jose, Sunnyvale, Santa Clara - CA"
-2008,41940,"San Jose, Sunnyvale, Santa Clara - CA"
-2009,41940,"San Jose, Sunnyvale, Santa Clara - CA"
-2010,41940,"San Jose, Sunnyvale, Santa Clara - CA"
-2011,41940,"San Jose, Sunnyvale, Santa Clara - CA"
-2012,41940,"San Jose, Sunnyvale, Santa Clara - CA"
-2007,41980,"San Juan, Caguas, Guaynabo - PR"
-2008,41980,"San Juan, Caguas, Guaynabo - PR"
-2009,41980,"San Juan, Caguas, Guaynabo - PR"
-2010,41980,"San Juan, Caguas, Guaynabo - PR"
-2011,41980,"San Juan, Caguas, Guaynabo - PR"
-2012,41980,"San Juan, Caguas, Guaynabo - PR"
-2007,42020,"San Luis Obispo, Paso Robles - CA"
-2008,42020,"San Luis Obispo, Paso Robles - CA"
-2009,42020,"San Luis Obispo, Paso Robles - CA"
-2010,42020,"San Luis Obispo, Paso Robles - CA"
-2011,42020,"San Luis Obispo, Paso Robles - CA"
-2012,42020,"San Luis Obispo, Paso Robles - CA"
+2013,41740,"San Diego, Carlsbad, San Marcos - CA"
 2007,41780,Sandusky - OH
 2008,41780,Sandusky - OH
 2009,41780,Sandusky - OH
 2010,41780,Sandusky - OH
 2011,41780,Sandusky - OH
 2012,41780,Sandusky - OH
+2013,41780,Sandusky - OH
+2007,41884,"San Francisco, San Mateo, Redwood City - CA"
+2008,41884,"San Francisco, San Mateo, Redwood City - CA"
+2009,41884,"San Francisco, San Mateo, Redwood City - CA"
+2010,41884,"San Francisco, San Mateo, Redwood City - CA"
+2011,41884,"San Francisco, San Mateo, Redwood City - CA"
+2012,41884,"San Francisco, San Mateo, Redwood City - CA"
+2013,41884,"San Francisco, San Mateo, Redwood City - CA"
+2007,41900,"San German, Cabo Rojo - PR"
+2008,41900,"San German, Cabo Rojo - PR"
+2009,41900,"San German, Cabo Rojo - PR"
+2010,41900,"San German, Cabo Rojo - PR"
+2011,41900,"San German, Cabo Rojo - PR"
+2012,41900,"San German, Cabo Rojo - PR"
+2013,41900,"San German, Cabo Rojo - PR"
+2007,41940,"San Jose, Sunnyvale, Santa Clara - CA"
+2008,41940,"San Jose, Sunnyvale, Santa Clara - CA"
+2009,41940,"San Jose, Sunnyvale, Santa Clara - CA"
+2010,41940,"San Jose, Sunnyvale, Santa Clara - CA"
+2011,41940,"San Jose, Sunnyvale, Santa Clara - CA"
+2012,41940,"San Jose, Sunnyvale, Santa Clara - CA"
+2013,41940,"San Jose, Sunnyvale, Santa Clara - CA"
+2007,41980,"San Juan, Caguas, Guaynabo - PR"
+2008,41980,"San Juan, Caguas, Guaynabo - PR"
+2009,41980,"San Juan, Caguas, Guaynabo - PR"
+2010,41980,"San Juan, Caguas, Guaynabo - PR"
+2011,41980,"San Juan, Caguas, Guaynabo - PR"
+2012,41980,"San Juan, Caguas, Guaynabo - PR"
+2013,41980,"San Juan, Caguas, Guaynabo - PR"
+2007,42020,"San Luis Obispo, Paso Robles - CA"
+2008,42020,"San Luis Obispo, Paso Robles - CA"
+2009,42020,"San Luis Obispo, Paso Robles - CA"
+2010,42020,"San Luis Obispo, Paso Robles - CA"
+2011,42020,"San Luis Obispo, Paso Robles - CA"
+2012,42020,"San Luis Obispo, Paso Robles - CA"
+2013,42020,"San Luis Obispo, Paso Robles - CA"
 2007,42044,"Santa Ana, Anaheim, Irvine - CA"
 2008,42044,"Santa Ana, Anaheim, Irvine - CA"
 2009,42044,"Santa Ana, Anaheim, Irvine - CA"
 2010,42044,"Santa Ana, Anaheim, Irvine - CA"
 2011,42044,"Santa Ana, Anaheim, Irvine - CA"
 2012,42044,"Santa Ana, Anaheim, Irvine - CA"
+2013,42044,"Santa Ana, Anaheim, Irvine - CA"
 2007,42060,"Santa Barbara, Santa Maria, Goleta - CA"
 2008,42060,"Santa Barbara, Santa Maria, Goleta - CA"
 2009,42060,"Santa Barbara, Santa Maria, Goleta - CA"
 2010,42060,"Santa Barbara, Santa Maria, Goleta - CA"
 2011,42060,"Santa Barbara, Santa Maria, Goleta - CA"
 2012,42060,"Santa Barbara, Santa Maria, Goleta - CA"
+2013,42060,"Santa Barbara, Santa Maria, Goleta - CA"
 2007,42100,"Santa Cruz, Watsonville - CA"
 2008,42100,"Santa Cruz, Watsonville - CA"
 2009,42100,"Santa Cruz, Watsonville - CA"
 2010,42100,"Santa Cruz, Watsonville - CA"
 2011,42100,"Santa Cruz, Watsonville - CA"
 2012,42100,"Santa Cruz, Watsonville - CA"
+2013,42100,"Santa Cruz, Watsonville - CA"
 2007,42140,Santa Fe - NM
 2008,42140,Santa Fe - NM
 2009,42140,Santa Fe - NM
 2010,42140,Santa Fe - NM
 2011,42140,Santa Fe - NM
 2012,42140,Santa Fe - NM
+2013,42140,Santa Fe - NM
 2007,42220,"Santa Rosa, Petaluma - CA"
 2008,42220,"Santa Rosa, Petaluma - CA"
 2009,42220,"Santa Rosa, Petaluma - CA"
 2010,42220,"Santa Rosa, Petaluma - CA"
 2011,42220,"Santa Rosa, Petaluma - CA"
 2012,42220,"Santa Rosa, Petaluma - CA"
+2013,42220,"Santa Rosa, Petaluma - CA"
 2007,42260,"Sarasota, Bradenton, Venice - FL"
 2007,42340,Savannah - GA
 2008,42340,Savannah - GA
@@ -1955,297 +2302,319 @@ year,code,name
 2010,42340,Savannah - GA
 2011,42340,Savannah - GA
 2012,42340,Savannah - GA
+2013,42340,Savannah - GA
 2007,42540,"Scranton, Wilkes, Barre - PA"
 2008,42540,"Scranton, Wilkes, Barre - PA"
 2009,42540,"Scranton, Wilkes, Barre - PA"
 2010,42540,"Scranton, Wilkes, Barre - PA"
 2011,42540,"Scranton, Wilkes, Barre - PA"
 2012,42540,"Scranton, Wilkes, Barre - PA"
+2013,42540,"Scranton, Wilkes, Barre - PA"
 2007,42644,"Seattle, Bellevue, Everett - WA"
 2008,42644,"Seattle, Bellevue, Everett - WA"
 2009,42644,"Seattle, Bellevue, Everett - WA"
 2010,42644,"Seattle, Bellevue, Everett - WA"
 2011,42644,"Seattle, Bellevue, Everett - WA"
 2012,42644,"Seattle, Bellevue, Everett - WA"
+2013,42644,"Seattle, Bellevue, Everett - WA"
 2007,42680,"Sebastian, Vero Beach - FL"
 2008,42680,"Sebastian, Vero Beach - FL"
 2009,42680,"Sebastian, Vero Beach - FL"
 2010,42680,"Sebastian, Vero Beach - FL"
 2011,42680,"Sebastian, Vero Beach - FL"
 2012,42680,"Sebastian, Vero Beach - FL"
+2013,42680,"Sebastian, Vero Beach - FL"
 2007,43100,Sheboygan - WI
 2008,43100,Sheboygan - WI
 2009,43100,Sheboygan - WI
 2010,43100,Sheboygan - WI
 2011,43100,Sheboygan - WI
 2012,43100,Sheboygan - WI
+2013,43100,Sheboygan - WI
 2007,43300,"Sherman, Denison - TX"
 2008,43300,"Sherman, Denison - TX"
 2009,43300,"Sherman, Denison - TX"
 2010,43300,"Sherman, Denison - TX"
 2011,43300,"Sherman, Denison - TX"
 2012,43300,"Sherman, Denison - TX"
+2013,43300,"Sherman, Denison - TX"
 2007,43340,"Shreveport, Bossier City - LA"
 2008,43340,"Shreveport, Bossier City - LA"
 2009,43340,"Shreveport, Bossier City - LA"
 2010,43340,"Shreveport, Bossier City - LA"
 2011,43340,"Shreveport, Bossier City - LA"
 2012,43340,"Shreveport, Bossier City - LA"
+2013,43340,"Shreveport, Bossier City - LA"
 2007,43580,"Sioux City - IA, NE, SD"
 2008,43580,"Sioux City - IA, NE, SD"
 2009,43580,"Sioux City - IA, NE, SD"
 2010,43580,"Sioux City - IA, NE, SD"
 2011,43580,"Sioux City - IA, NE, SD"
 2012,43580,"Sioux City - IA, NE, SD"
+2013,43580,"Sioux City - IA, NE, SD"
 2007,43620,Sioux Falls - SD
 2008,43620,Sioux Falls - SD
 2009,43620,Sioux Falls - SD
 2010,43620,Sioux Falls - SD
 2011,43620,Sioux Falls - SD
 2012,43620,Sioux Falls - SD
+2013,43620,Sioux Falls - SD
 2007,43780,"South Bend, Mishawaka - IN, MI"
 2008,43780,"South Bend, Mishawaka - IN, MI"
 2009,43780,"South Bend, Mishawaka - IN, MI"
 2010,43780,"South Bend, Mishawaka - IN, MI"
 2011,43780,"South Bend, Mishawaka - IN, MI"
 2012,43780,"South Bend, Mishawaka - IN, MI"
+2013,43780,"South Bend, Mishawaka - IN, MI"
 2007,43900,Spartanburg - SC
 2008,43900,Spartanburg - SC
 2009,43900,Spartanburg - SC
 2010,43900,Spartanburg - SC
 2011,43900,Spartanburg - SC
 2012,43900,Spartanburg - SC
+2013,43900,Spartanburg - SC
 2007,44060,Spokane - WA
 2008,44060,Spokane - WA
 2009,44060,Spokane - WA
 2010,44060,Spokane - WA
 2011,44060,Spokane - WA
 2012,44060,Spokane - WA
+2013,44060,Spokane - WA
 2007,44100,Springfield - IL
 2008,44100,Springfield - IL
 2009,44100,Springfield - IL
 2010,44100,Springfield - IL
 2011,44100,Springfield - IL
 2012,44100,Springfield - IL
+2013,44100,Springfield - IL
 2007,44140,Springfield - MA
 2008,44140,Springfield - MA
 2009,44140,Springfield - MA
 2010,44140,Springfield - MA
 2011,44140,Springfield - MA
 2012,44140,Springfield - MA
+2013,44140,Springfield - MA
 2007,44180,Springfield - MO
 2008,44180,Springfield - MO
 2009,44180,Springfield - MO
 2010,44180,Springfield - MO
 2011,44180,Springfield - MO
 2012,44180,Springfield - MO
+2013,44180,Springfield - MO
 2007,44220,Springfield - OH
 2008,44220,Springfield - OH
 2009,44220,Springfield - OH
 2010,44220,Springfield - OH
 2011,44220,Springfield - OH
 2012,44220,Springfield - OH
-2007,41060,St. Cloud - MN
-2008,41060,St. Cloud - MN
-2009,41060,St. Cloud - MN
-2010,41060,St. Cloud - MN
-2011,41060,St. Cloud - MN
-2012,41060,St. Cloud - MN
-2007,41100,St. George - UT
-2008,41100,St. George - UT
-2009,41100,St. George - UT
-2010,41100,St. George - UT
-2011,41100,St. George - UT
-2012,41100,St. George - UT
-2007,41140,"St. Joseph - MO, KS"
-2008,41140,"St. Joseph - MO, KS"
-2009,41140,"St. Joseph - MO, KS"
-2010,41140,"St. Joseph - MO, KS"
-2011,41140,"St. Joseph - MO, KS"
-2012,41140,"St. Joseph - MO, KS"
-2007,41180,"St. Louis - MO, IL"
-2008,41180,"St. Louis - MO, IL"
-2009,41180,"St. Louis - MO, IL"
-2010,41180,"St. Louis - MO, IL"
-2011,41180,"St. Louis - MO, IL"
-2012,41180,"St. Louis - MO, IL"
+2013,44220,Springfield - OH
 2007,44300,State College - PA
 2008,44300,State College - PA
 2009,44300,State College - PA
 2010,44300,State College - PA
 2011,44300,State College - PA
 2012,44300,State College - PA
+2013,44300,State College - PA
 2010,44600,"Steubenville, Weirton - OH, WV"
 2011,44600,"Steubenville, Weirton - OH, WV"
 2012,44600,"Steubenville, Weirton - OH, WV"
+2013,44600,"Steubenville, Weirton - OH, WV"
 2007,44700,Stockton - CA
 2008,44700,Stockton - CA
 2009,44700,Stockton - CA
 2010,44700,Stockton - CA
 2011,44700,Stockton - CA
 2012,44700,Stockton - CA
+2013,44700,Stockton - CA
 2007,44940,Sumter - SC
 2008,44940,Sumter - SC
 2009,44940,Sumter - SC
 2010,44940,Sumter - SC
 2011,44940,Sumter - SC
 2012,44940,Sumter - SC
+2013,44940,Sumter - SC
 2007,45060,Syracuse - NY
 2008,45060,Syracuse - NY
 2009,45060,Syracuse - NY
 2010,45060,Syracuse - NY
 2011,45060,Syracuse - NY
 2012,45060,Syracuse - NY
+2013,45060,Syracuse - NY
 2007,45104,Tacoma - WA
 2008,45104,Tacoma - WA
 2009,45104,Tacoma - WA
 2010,45104,Tacoma - WA
 2011,45104,Tacoma - WA
 2012,45104,Tacoma - WA
+2013,45104,Tacoma - WA
 2007,45220,Tallahassee - FL
 2008,45220,Tallahassee - FL
 2009,45220,Tallahassee - FL
 2010,45220,Tallahassee - FL
 2011,45220,Tallahassee - FL
 2012,45220,Tallahassee - FL
+2013,45220,Tallahassee - FL
 2007,45300,"Tampa, St. Petersburg, Clearwater - FL"
 2008,45300,"Tampa, St. Petersburg, Clearwater - FL"
 2009,45300,"Tampa, St. Petersburg, Clearwater - FL"
 2010,45300,"Tampa, St. Petersburg, Clearwater - FL"
 2011,45300,"Tampa, St. Petersburg, Clearwater - FL"
 2012,45300,"Tampa, St. Petersburg, Clearwater - FL"
+2013,45300,"Tampa, St. Petersburg, Clearwater - FL"
 2007,45460,Terre Haute - IN
 2008,45460,Terre Haute - IN
 2009,45460,Terre Haute - IN
 2010,45460,Terre Haute - IN
 2011,45460,Terre Haute - IN
 2012,45460,Terre Haute - IN
+2013,45460,Terre Haute - IN
 2007,45500,"Texarkana, TX - Texarkana, AR"
 2008,45500,"Texarkana, TX - Texarkana, AR"
 2009,45500,"Texarkana, TX - Texarkana, AR"
 2010,45500,"Texarkana, TX - Texarkana, AR"
 2011,45500,"Texarkana, TX - Texarkana, AR"
 2012,45500,"Texarkana, TX - Texarkana, AR"
+2013,45500,"Texarkana, TX - Texarkana, AR"
 2007,45780,Toledo - OH
 2008,45780,Toledo - OH
 2009,45780,Toledo - OH
 2010,45780,Toledo - OH
 2011,45780,Toledo - OH
 2012,45780,Toledo - OH
+2013,45780,Toledo - OH
 2007,45820,Topeka - KS
 2008,45820,Topeka - KS
 2009,45820,Topeka - KS
 2010,45820,Topeka - KS
 2011,45820,Topeka - KS
 2012,45820,Topeka - KS
+2013,45820,Topeka - KS
 2007,45940,"Trenton, Ewing - NJ"
 2008,45940,"Trenton, Ewing - NJ"
 2009,45940,"Trenton, Ewing - NJ"
 2010,45940,"Trenton, Ewing - NJ"
 2011,45940,"Trenton, Ewing - NJ"
 2012,45940,"Trenton, Ewing - NJ"
+2013,45940,"Trenton, Ewing - NJ"
 2007,46060,Tucson - AZ
 2008,46060,Tucson - AZ
 2009,46060,Tucson - AZ
 2010,46060,Tucson - AZ
 2011,46060,Tucson - AZ
 2012,46060,Tucson - AZ
+2013,46060,Tucson - AZ
 2007,46140,Tulsa - OK
 2008,46140,Tulsa - OK
 2009,46140,Tulsa - OK
 2010,46140,Tulsa - OK
 2011,46140,Tulsa - OK
 2012,46140,Tulsa - OK
+2013,46140,Tulsa - OK
 2007,46220,Tuscaloosa - AL
 2008,46220,Tuscaloosa - AL
 2009,46220,Tuscaloosa - AL
 2010,46220,Tuscaloosa - AL
 2011,46220,Tuscaloosa - AL
 2012,46220,Tuscaloosa - AL
+2013,46220,Tuscaloosa - AL
 2007,46340,Tyler - TX
 2008,46340,Tyler - TX
 2009,46340,Tyler - TX
 2010,46340,Tyler - TX
 2011,46340,Tyler - TX
 2012,46340,Tyler - TX
+2013,46340,Tyler - TX
 2007,46540,"Utica, Rome - NY"
 2008,46540,"Utica, Rome - NY"
 2009,46540,"Utica, Rome - NY"
 2010,46540,"Utica, Rome - NY"
 2011,46540,"Utica, Rome - NY"
 2012,46540,"Utica, Rome - NY"
+2013,46540,"Utica, Rome - NY"
 2007,46660,Valdosta - GA
 2008,46660,Valdosta - GA
 2009,46660,Valdosta - GA
 2010,46660,Valdosta - GA
 2011,46660,Valdosta - GA
 2012,46660,Valdosta - GA
+2013,46660,Valdosta - GA
 2007,46700,"Vallejo, Fairfield - CA"
 2008,46700,"Vallejo, Fairfield - CA"
 2009,46700,"Vallejo, Fairfield - CA"
 2010,46700,"Vallejo, Fairfield - CA"
 2011,46700,"Vallejo, Fairfield - CA"
 2012,46700,"Vallejo, Fairfield - CA"
+2013,46700,"Vallejo, Fairfield - CA"
 2007,47020,Victoria - TX
 2008,47020,Victoria - TX
 2009,47020,Victoria - TX
 2010,47020,Victoria - TX
 2011,47020,Victoria - TX
 2012,47020,Victoria - TX
+2013,47020,Victoria - TX
 2007,47220,"Vineland, Millville, Bridgeton - NJ"
 2008,47220,"Vineland, Millville, Bridgeton - NJ"
 2009,47220,"Vineland, Millville, Bridgeton - NJ"
 2010,47220,"Vineland, Millville, Bridgeton - NJ"
 2011,47220,"Vineland, Millville, Bridgeton - NJ"
 2012,47220,"Vineland, Millville, Bridgeton - NJ"
+2013,47220,"Vineland, Millville, Bridgeton - NJ"
 2007,47260,"Virginia Beach, Norfolk, Newport News - VA, NC"
 2008,47260,"Virginia Beach, Norfolk, Newport News - VA, NC"
 2009,47260,"Virginia Beach, Norfolk, Newport News - VA, NC"
 2010,47260,"Virginia Beach, Norfolk, Newport News - VA, NC"
 2011,47260,"Virginia Beach, Norfolk, Newport News - VA, NC"
 2012,47260,"Virginia Beach, Norfolk, Newport News - VA, NC"
+2013,47260,"Virginia Beach, Norfolk, Newport News - VA, NC"
 2007,47300,"Visalia, Porterville - CA"
 2008,47300,"Visalia, Porterville - CA"
 2009,47300,"Visalia, Porterville - CA"
 2010,47300,"Visalia, Porterville - CA"
 2011,47300,"Visalia, Porterville - CA"
 2012,47300,"Visalia, Porterville - CA"
+2013,47300,"Visalia, Porterville - CA"
 2007,47380,Waco - TX
 2008,47380,Waco - TX
 2009,47380,Waco - TX
 2010,47380,Waco - TX
 2011,47380,Waco - TX
 2012,47380,Waco - TX
+2013,47380,Waco - TX
 2007,47580,Warner Robins - GA
 2008,47580,Warner Robins - GA
 2009,47580,Warner Robins - GA
 2010,47580,Warner Robins - GA
 2011,47580,Warner Robins - GA
 2012,47580,Warner Robins - GA
+2013,47580,Warner Robins - GA
 2007,47644,"Warren, Troy, Farmington Hills - MI"
 2008,47644,"Warren, Troy, Farmington Hills - MI"
 2009,47644,"Warren, Troy, Farmington Hills - MI"
 2010,47644,"Warren, Troy, Farmington Hills - MI"
 2011,47644,"Warren, Troy, Farmington Hills - MI"
 2012,47644,"Warren, Troy, Farmington Hills - MI"
+2013,47644,"Warren, Troy, Farmington Hills - MI"
 2007,47894,"Washington, Arlington, Alexandria - DC, VA, MD, WV"
 2008,47894,"Washington, Arlington, Alexandria - DC, VA, MD, WV"
 2009,47894,"Washington, Arlington, Alexandria - DC, VA, MD, WV"
 2010,47894,"Washington, Arlington, Alexandria - DC, VA, MD, WV"
 2011,47894,"Washington, Arlington, Alexandria - DC, VA, MD, WV"
 2012,47894,"Washington, Arlington, Alexandria - DC, VA, MD, WV"
+2013,47894,"Washington, Arlington, Alexandria - DC, VA, MD, WV"
 2007,47940,"Waterloo, Cedar Falls - IA"
 2008,47940,"Waterloo, Cedar Falls - IA"
 2009,47940,"Waterloo, Cedar Falls - IA"
 2010,47940,"Waterloo, Cedar Falls - IA"
 2011,47940,"Waterloo, Cedar Falls - IA"
 2012,47940,"Waterloo, Cedar Falls - IA"
+2013,47940,"Waterloo, Cedar Falls - IA"
 2007,48140,Wausau - WI
 2008,48140,Wausau - WI
 2009,48140,Wausau - WI
 2010,48140,Wausau - WI
 2011,48140,Wausau - WI
 2012,48140,Wausau - WI
+2013,48140,Wausau - WI
 2007,48260,"Weirton, Steubenville - WV, OH"
 2008,48260,"Weirton, Steubenville - WV, OH"
 2009,48260,"Weirton, Steubenville - WV, OH"
@@ -2255,492 +2624,123 @@ year,code,name
 2010,48300,"Wenatchee, East Wenatchee - WA"
 2011,48300,"Wenatchee, East Wenatchee - WA"
 2012,48300,"Wenatchee, East Wenatchee - WA"
+2013,48300,"Wenatchee, East Wenatchee - WA"
 2007,48424,"West Palm Beach, Boca Raton, Boynton Beach - FL"
 2008,48424,"West Palm Beach, Boca Raton, Boynton Beach - FL"
 2009,48424,"West Palm Beach, Boca Raton, Boynton Beach - FL"
 2010,48424,"West Palm Beach, Boca Raton, Boynton Beach - FL"
 2011,48424,"West Palm Beach, Boca Raton, Boynton Beach - FL"
 2012,48424,"West Palm Beach, Boca Raton, Boynton Beach - FL"
+2013,48424,"West Palm Beach, Boca Raton, Boynton Beach - FL"
 2007,48540,"Wheeling - WV, OH"
 2008,48540,"Wheeling - WV, OH"
 2009,48540,"Wheeling - WV, OH"
 2010,48540,"Wheeling - WV, OH"
 2011,48540,"Wheeling - WV, OH"
 2012,48540,"Wheeling - WV, OH"
+2013,48540,"Wheeling - WV, OH"
 2007,48620,Wichita - KS
 2008,48620,Wichita - KS
 2009,48620,Wichita - KS
 2010,48620,Wichita - KS
 2011,48620,Wichita - KS
 2012,48620,Wichita - KS
+2013,48620,Wichita - KS
 2007,48660,Wichita Falls - TX
 2008,48660,Wichita Falls - TX
 2009,48660,Wichita Falls - TX
 2010,48660,Wichita Falls - TX
 2011,48660,Wichita Falls - TX
 2012,48660,Wichita Falls - TX
+2013,48660,Wichita Falls - TX
 2007,48700,Williamsport - PA
 2008,48700,Williamsport - PA
 2009,48700,Williamsport - PA
 2010,48700,Williamsport - PA
 2011,48700,Williamsport - PA
 2012,48700,Williamsport - PA
+2013,48700,Williamsport - PA
 2007,48864,"Wilmington - DE, MD, NJ"
 2008,48864,"Wilmington - DE, MD, NJ"
 2009,48864,"Wilmington - DE, MD, NJ"
 2010,48864,"Wilmington - DE, MD, NJ"
 2011,48864,"Wilmington - DE, MD, NJ"
 2012,48864,"Wilmington - DE, MD, NJ"
+2013,48864,"Wilmington - DE, MD, NJ"
 2007,48900,Wilmington - NC
 2008,48900,Wilmington - NC
 2009,48900,Wilmington - NC
 2010,48900,Wilmington - NC
 2011,48900,Wilmington - NC
 2012,48900,Wilmington - NC
+2013,48900,Wilmington - NC
 2007,49020,"Winchester - VA, WV"
 2008,49020,"Winchester - VA, WV"
 2009,49020,"Winchester - VA, WV"
 2010,49020,"Winchester - VA, WV"
 2011,49020,"Winchester - VA, WV"
 2012,49020,"Winchester - VA, WV"
+2013,49020,"Winchester - VA, WV"
 2007,49180,"Winston, Salem - NC"
 2008,49180,"Winston, Salem - NC"
 2009,49180,"Winston, Salem - NC"
 2010,49180,"Winston, Salem - NC"
 2011,49180,"Winston, Salem - NC"
 2012,49180,"Winston, Salem - NC"
+2013,49180,"Winston, Salem - NC"
 2007,49340,Worcester - MA
 2008,49340,Worcester - MA
 2009,49340,Worcester - MA
 2010,49340,Worcester - MA
 2011,49340,Worcester - MA
 2012,49340,Worcester - MA
+2013,49340,Worcester - MA
 2007,49420,Yakima - WA
 2008,49420,Yakima - WA
 2009,49420,Yakima - WA
 2010,49420,Yakima - WA
 2011,49420,Yakima - WA
 2012,49420,Yakima - WA
+2013,49420,Yakima - WA
 2007,49500,Yauco - PR
 2008,49500,Yauco - PR
 2009,49500,Yauco - PR
 2010,49500,Yauco - PR
 2011,49500,Yauco - PR
 2012,49500,Yauco - PR
+2013,49500,Yauco - PR
 2007,49620,"York, Hanover - PA"
 2008,49620,"York, Hanover - PA"
 2009,49620,"York, Hanover - PA"
 2010,49620,"York, Hanover - PA"
 2011,49620,"York, Hanover - PA"
 2012,49620,"York, Hanover - PA"
+2013,49620,"York, Hanover - PA"
 2007,49660,"Youngstown, Warren, Boardman - OH, PA"
 2008,49660,"Youngstown, Warren, Boardman - OH, PA"
 2009,49660,"Youngstown, Warren, Boardman - OH, PA"
 2010,49660,"Youngstown, Warren, Boardman - OH, PA"
 2011,49660,"Youngstown, Warren, Boardman - OH, PA"
 2012,49660,"Youngstown, Warren, Boardman - OH, PA"
+2013,49660,"Youngstown, Warren, Boardman - OH, PA"
 2007,49700,Yuba City - CA
 2008,49700,Yuba City - CA
 2009,49700,Yuba City - CA
 2010,49700,Yuba City - CA
 2011,49700,Yuba City - CA
 2012,49700,Yuba City - CA
+2013,49700,Yuba City - CA
 2007,49740,Yuma - AZ
 2008,49740,Yuma - AZ
 2009,49740,Yuma - AZ
 2010,49740,Yuma - AZ
 2011,49740,Yuma - AZ
 2012,49740,Yuma - AZ
-2013,10180,Abilene - TX
-2013,10380,"Aguadilla, Isabela, San Sebastian - PR"
-2013,10420,Akron - OH
-2013,10500,Albany - GA
-2013,10580,"Albany, Schenectady, Troy - NY"
-2013,10740,Albuquerque - NM
-2013,10780,Alexandria - LA
-2013,10900,"Allentown, Bethlehem, Easton - PA, NJ"
-2013,11020,Altoona - PA
-2013,11100,Amarillo - TX
-2013,11180,Ames - IA
-2013,11260,Anchorage - AK
-2013,11300,Anderson - IN
-2013,11340,Anderson - SC
-2013,11460,Ann Arbor - MI
-2013,11500,"Anniston, Oxford - AL"
-2013,11540,Appleton - WI
-2013,11700,Asheville - NC
-2013,12020,"Athens, Clarke County - GA"
-2013,12060,"Atlanta, Sandy Springs, Marietta - GA"
-2013,12100,"Atlantic City, Hammonton - NJ"
-2013,12220,"Auburn, Opelika - AL"
-2013,12260,"Augusta, Richmond County - GA, SC"
-2013,12420,"Austin, Round Rock, San Marcos - TX"
-2013,12540,"Bakersfield, Delano - CA"
-2013,12580,"Baltimore, Towson - MD"
-2013,12620,Bangor - ME
-2013,12700,Barnstable Town - MA
-2013,12940,Baton Rouge - LA
-2013,12980,Battle Creek - MI
-2013,13020,Bay City - MI
-2013,13140,"Beaumont, Port Arthur - TX"
-2013,13380,Bellingham - WA
-2013,13460,Bend - OR
-2013,13644,"Bethesda, Rockville, Frederick - MD"
-2013,13740,Billings - MT
-2013,13780,Binghamton - NY
-2013,13820,"Birmingham, Hoover - AL"
-2013,13900,Bismarck - ND
-2013,13980,"Blacksburg, Christiansburg, Radford - VA"
-2013,14020,Bloomington - IN
-2013,14060,"Bloomington, Normal - IL"
-2013,14260,"Boise City, Nampa - ID"
-2013,14484,"Boston, Quincy - MA"
-2013,14500,Boulder - CO
-2013,14540,Bowling Green - KY
-2013,14740,"Bremerton, Silverdale - WA"
-2013,14860,"Bridgeport, Stamford, Norwalk - CT"
-2013,15180,"Brownsville, Harlingen - TX"
-2013,15260,Brunswick - GA
-2013,15380,"Buffalo, Niagara Falls - NY"
-2013,15500,Burlington - NC
-2013,15540,"Burlington, South Burlington - VT"
-2013,15764,"Cambridge, Newton, Framingham - MA"
-2013,15804,Camden - NJ
-2013,15940,"Canton, Massillon - OH"
-2013,15980,"Cape Coral, Fort Myers - FL"
-2013,16020,"Cape Girardeau, Jackson - MO, IL"
-2013,16180,Carson City - NV
-2013,16220,Casper - WY
-2013,16300,Cedar Rapids - IA
-2013,16580,"Champaign, Urbana - IL"
-2013,16620,Charleston - WV
-2013,16700,"Charleston, North Charleston, Summerville - SC"
-2013,16740,"Charlotte, Gastonia, Rock Hill - NC, SC"
-2013,16820,Charlottesville - VA
-2013,16860,"Chattanooga - TN, GA"
-2013,16940,Cheyenne - WY
-2013,16974,"Chicago, Joliet, Naperville - IL"
-2013,17020,Chico - CA
-2013,17140,"Cincinnati, Middletown - OH, KY, IN"
-2013,17300,"Clarksville - TN, KY"
-2013,17420,Cleveland - TN
-2013,17460,"Cleveland, Elyria, Mentor - OH"
-2013,17660,Coeur D'Alene - ID
-2013,17780,"College Station, Bryan - TX"
-2013,17820,Colorado Springs - CO
-2013,17860,Columbia - MO
-2013,17900,Columbia - SC
-2013,17980,"Columbus - GA, AL"
-2013,18020,Columbus - IN
-2013,18140,Columbus - OH
-2013,18580,Corpus Christi - TX
-2013,18700,Corvallis - OR
-2013,18880,"Crestview, Fort Walton Beach, Destin - FL"
-2013,19060,"Cumberland - MD, WV"
-2013,19124,"Dallas, Plano, Irving - TX"
-2013,19140,Dalton - GA
-2013,19180,Danville - IL
-2013,19260,Danville - VA
-2013,19340,"Davenport, Moline, Rock Island - IA, IL"
-2013,19380,Dayton - OH
-2013,19460,Decatur - AL
-2013,19500,Decatur - IL
-2013,19660,"Deltona, Daytona Beach, Ormond Beach - FL"
-2013,19740,"Denver, Aurora, Broomfield - CO"
-2013,19780,"Des Moines, West Des Moines - IA"
-2013,19804,"Detroit, Livonia, Dearborn - MI"
-2013,20020,Dothan - AL
-2013,20100,Dover - DE
-2013,20220,Dubuque - IA
-2013,20260,"Duluth - MN, WI"
-2013,20500,"Durham, Chapel Hill - NC"
-2013,20740,Eau Claire - WI
-2013,20764,"Edison, New Brunswick - NJ"
-2013,20940,El Centro - CA
-2013,21060,Elizabethtown - KY
-2013,21140,"Elkhart, Goshen - IN"
-2013,21300,Elmira - NY
-2013,21340,El Paso - TX
-2013,21500,Erie - PA
-2013,21660,"Eugene, Springfield - OR"
-2013,21780,"Evansville - IN, KY"
-2013,21820,Fairbanks - AK
-2013,21940,Fajardo - PR
-2013,22020,"Fargo - ND, MN"
-2013,22140,Farmington - NM
-2013,22180,Fayetteville - NC
-2013,22220,"Fayetteville, Springdale, Rogers - AR, MO"
-2013,22380,Flagstaff - AZ
-2013,22420,Flint - MI
-2013,22500,Florence - SC
-2013,22520,"Florence, Muscle Shoals - AL"
-2013,22540,Fond du Lac - WI
-2013,22660,"Fort Collins, Loveland - CO"
-2013,22744,"Fort Lauderdale, Pompano Beach, Deerfield Beach - FL"
-2013,22900,"Fort Smith - AR, OK"
-2013,23060,Fort Wayne - IN
-2013,23104,"Fort Worth, Arlington - TX"
-2013,23420,Fresno - CA
-2013,23460,Gadsden - AL
-2013,23540,Gainesville - FL
-2013,23580,Gainesville - GA
-2013,23844,Gary - IN
-2013,24020,Glens Falls - NY
-2013,24140,Goldsboro - NC
-2013,24220,"Grand Forks - ND, MN"
-2013,24300,Grand Junction - CO
-2013,24340,"Grand Rapids, Wyoming - MI"
-2013,24500,Great Falls - MT
-2013,24540,Greeley - CO
-2013,24580,Green Bay - WI
-2013,24660,"Greensboro, High Point - NC"
-2013,24780,Greenville - NC
-2013,24860,"Greenville, Mauldin, Easley - SC"
-2013,25020,Guayama - PR
-2013,25060,"Gulfport, Biloxi - MS"
-2013,25180,"Hagerstown, Martinsburg - MD, WV"
-2013,25260,"Hanford, Corcoran - CA"
-2013,25420,"Harrisburg, Carlisle - PA"
-2013,25500,Harrisonburg - VA
-2013,25540,"Hartford, West Hartford, East Hartford - CT"
-2013,25620,Hattiesburg - MS
-2013,25860,"Hickory, Lenoir, Morganton - NC"
-2013,25980,"Hinesville, Fort Stewart - GA"
-2013,26100,"Holland, Grand Haven - MI"
-2013,26180,Honolulu - HI
-2013,26300,Hot Springs - AR
-2013,26380,"Houma, Bayou Cane, Thibodaux - LA"
-2013,26420,"Houston, Sugar Land, Baytown - TX"
-2013,26580,"Huntington, Ashland - WV, KY, OH"
-2013,26620,Huntsville - AL
-2013,26820,Idaho Falls - ID
-2013,26900,"Indianapolis, Carmel - IN"
-2013,26980,Iowa City - IA
-2013,27060,Ithaca - NY
-2013,27100,Jackson - MI
-2013,27140,Jackson - MS
-2013,27180,Jackson - TN
-2013,27260,Jacksonville - FL
-2013,27340,Jacksonville - NC
-2013,27500,Janesville - WI
-2013,27620,Jefferson City - MO
-2013,27740,Johnson City - TN
-2013,27780,Johnstown - PA
-2013,27860,Jonesboro - AR
-2013,27900,Joplin - MO
-2013,28020,"Kalamazoo, Portage - MI"
-2013,28100,"Kankakee, Bradley - IL"
-2013,28140,"Kansas City - MO, KS"
-2013,28420,"Kennewick, Pasco, Richland - WA"
-2013,28660,"Killeen, Temple, Fort Hood - TX"
-2013,28700,"Kingsport, Bristol, Bristol - TN, VA"
-2013,28740,Kingston - NY
-2013,28940,Knoxville - TN
-2013,29020,Kokomo - IN
-2013,29100,"La Crosse - WI, MN"
-2013,29140,Lafayette - IN
-2013,29180,Lafayette - LA
-2013,29340,Lake Charles - LA
-2013,29404,"Lake County, Kenosha County - IL, WI"
-2013,29420,"Lake Havasu City, Kingman - AZ"
-2013,29460,"Lakeland, Winter Haven - FL"
-2013,29540,Lancaster - PA
-2013,29620,"Lansing, East Lansing - MI"
-2013,29700,Laredo - TX
-2013,29740,Las Cruces - NM
-2013,29820,"Las Vegas, Paradise - NV"
-2013,29940,Lawrence - KS
-2013,30020,Lawton - OK
-2013,30140,Lebanon - PA
-2013,30300,"Lewiston - ID, WA"
-2013,30340,"Lewiston, Auburn - ME"
-2013,30460,"Lexington, Fayette - KY"
-2013,30620,Lima - OH
-2013,30700,Lincoln - NE
-2013,30780,"Little Rock, North Little Rock, Conway - AR"
-2013,30860,"Logan - UT, ID"
-2013,30980,Longview - TX
-2013,31020,Longview - WA
-2013,31084,"Los Angeles, Long Beach, Glendale - CA"
-2013,31140,"Louisville, Jefferson County - KY, IN"
-2013,31180,Lubbock - TX
-2013,31340,Lynchburg - VA
-2013,31420,Macon - GA
-2013,31460,"Madera, Chowchilla - CA"
-2013,31540,Madison - WI
-2013,31700,"Manchester, Nashua - NH"
-2013,31740,Manhattan - KS
-2013,31860,"Mankato, North Mankato - MN"
-2013,31900,Mansfield - OH
-2013,32420,Mayaguez - PR
-2013,32580,"McAllen, Edinburg, Mission - TX"
-2013,32780,Medford - OR
-2013,32820,"Memphis - TN, MS, AR"
-2013,32900,Merced - CA
-2013,33124,"Miami, Miami Beach, Kendall - FL"
-2013,33140,"Michigan City, La Porte - IN"
-2013,33260,Midland - TX
-2013,33340,"Milwaukee, Waukesha, West Allis - WI"
-2013,33460,"Minneapolis, St. Paul, Bloomington - MN, WI"
-2013,33540,Missoula - MT
-2013,33660,Mobile - AL
-2013,33700,Modesto - CA
-2013,33740,Monroe - LA
-2013,33780,Monroe - MI
-2013,33860,Montgomery - AL
-2013,34060,Morgantown - WV
-2013,34100,Morristown - TN
-2013,34580,"Mount Vernon, Anacortes - WA"
-2013,34620,Muncie - IN
-2013,34740,"Muskegon, Norton Shores - MI"
-2013,34820,"Myrtle Beach, North Myrtle Beach, Conway - SC"
-2013,34900,Napa - CA
-2013,34940,"Naples, Marco Island - FL"
-2013,34980,"Nashville, Davidson, Murfreesboro, Franklin - TN"
-2013,35004,"Nassau, Suffolk - NY"
-2013,35084,"Newark, Union - NJ, PA"
-2013,35300,"New Haven, Milford - CT"
-2013,35380,"New Orleans, Metairie, Kenner - LA"
-2013,35644,"New York, White Plains, Wayne - NY, NJ"
-2013,35660,"Niles, Benton Harbor - MI"
-2013,35840,"North Port, Bradenton, Sarasota - FL"
-2013,35980,"Norwich, New London - CT"
-2013,36084,"Oakland, Fremont, Hayward - CA"
-2013,36100,Ocala - FL
-2013,36140,Ocean City - NJ
-2013,36220,Odessa - TX
-2013,36260,"Ogden, Clearfield - UT"
-2013,36420,Oklahoma City - OK
-2013,36500,Olympia - WA
-2013,36540,"Omaha, Council Bluffs - NE, IA"
-2013,36740,"Orlando, Kissimmee, Sanford - FL"
-2013,36780,"Oshkosh, Neenah - WI"
-2013,36980,Owensboro - KY
-2013,37100,"Oxnard, Thousand Oaks, Ventura - CA"
-2013,37340,"Palm Bay, Melbourne, Titusville - FL"
-2013,37380,Palm Coast - FL
-2013,37460,"Panama City, Lynn Haven, Panama City Beach - FL"
-2013,37620,"Parkersburg, Marietta, Vienna - WV, OH"
-2013,37700,Pascagoula - MS
-2013,37764,Peabody - MA
-2013,37860,"Pensacola, Ferry Pass, Brent - FL"
-2013,37900,Peoria - IL
-2013,37964,Philadelphia - PA
-2013,38060,"Phoenix, Mesa, Glendale - AZ"
-2013,38220,Pine Bluff - AR
-2013,38300,Pittsburgh - PA
-2013,38340,Pittsfield - MA
-2013,38540,Pocatello - ID
-2013,38660,Ponce - PR
-2013,38860,"Portland, South Portland, Biddeford - ME"
-2013,38900,"Portland, Vancouver, Hillsboro - OR, WA"
-2013,38940,Port St. Lucie - FL
-2013,39100,"Poughkeepsie, Newburgh, Middletown - NY"
-2013,39140,Prescott - AZ
-2013,39300,"Providence, New Bedford, Fall River - RI, MA"
-2013,39340,"Provo, Orem - UT"
-2013,39380,Pueblo - CO
-2013,39460,Punta Gorda - FL
-2013,39540,Racine - WI
-2013,39580,"Raleigh, Cary - NC"
-2013,39660,Rapid City - SD
-2013,39740,Reading - PA
-2013,39820,Redding - CA
-2013,39900,"Reno, Sparks - NV"
-2013,40060,Richmond - VA
-2013,40140,"Riverside, San Bernardino, Ontario - CA"
-2013,40220,Roanoke - VA
-2013,40340,Rochester - MN
-2013,40380,Rochester - NY
-2013,40420,Rockford - IL
-2013,40484,"Rockingham County, Strafford County - NH"
-2013,40580,Rocky Mount - NC
-2013,40660,Rome - GA
-2013,40900,"Sacramento, Arden, Arcade, Roseville - CA"
-2013,40980,"Saginaw, Saginaw Township North - MI"
-2013,41060,St. Cloud - MN
-2013,41100,St. George - UT
-2013,41140,"St. Joseph - MO, KS"
-2013,41180,"St. Louis - MO, IL"
-2013,41420,Salem - OR
-2013,41500,Salinas - CA
-2013,41540,Salisbury - MD
-2013,41620,Salt Lake City - UT
-2013,41660,San Angelo - TX
-2013,41700,"San Antonio, New Braunfels - TX"
-2013,41740,"San Diego, Carlsbad, San Marcos - CA"
-2013,41780,Sandusky - OH
-2013,41884,"San Francisco, San Mateo, Redwood City - CA"
-2013,41900,"San German, Cabo Rojo - PR"
-2013,41940,"San Jose, Sunnyvale, Santa Clara - CA"
-2013,41980,"San Juan, Caguas, Guaynabo - PR"
-2013,42020,"San Luis Obispo, Paso Robles - CA"
-2013,42044,"Santa Ana, Anaheim, Irvine - CA"
-2013,42060,"Santa Barbara, Santa Maria, Goleta - CA"
-2013,42100,"Santa Cruz, Watsonville - CA"
-2013,42140,Santa Fe - NM
-2013,42220,"Santa Rosa, Petaluma - CA"
-2013,42340,Savannah - GA
-2013,42540,"Scranton, Wilkes, Barre - PA"
-2013,42644,"Seattle, Bellevue, Everett - WA"
-2013,42680,"Sebastian, Vero Beach - FL"
-2013,43100,Sheboygan - WI
-2013,43300,"Sherman, Denison - TX"
-2013,43340,"Shreveport, Bossier City - LA"
-2013,43580,"Sioux City - IA, NE, SD"
-2013,43620,Sioux Falls - SD
-2013,43780,"South Bend, Mishawaka - IN, MI"
-2013,43900,Spartanburg - SC
-2013,44060,Spokane - WA
-2013,44100,Springfield - IL
-2013,44140,Springfield - MA
-2013,44180,Springfield - MO
-2013,44220,Springfield - OH
-2013,44300,State College - PA
-2013,44600,"Steubenville, Weirton - OH, WV"
-2013,44700,Stockton - CA
-2013,44940,Sumter - SC
-2013,45060,Syracuse - NY
-2013,45104,Tacoma - WA
-2013,45220,Tallahassee - FL
-2013,45300,"Tampa, St. Petersburg, Clearwater - FL"
-2013,45460,Terre Haute - IN
-2013,45500,"Texarkana, TX - Texarkana, AR"
-2013,45780,Toledo - OH
-2013,45820,Topeka - KS
-2013,45940,"Trenton, Ewing - NJ"
-2013,46060,Tucson - AZ
-2013,46140,Tulsa - OK
-2013,46220,Tuscaloosa - AL
-2013,46340,Tyler - TX
-2013,46540,"Utica, Rome - NY"
-2013,46660,Valdosta - GA
-2013,46700,"Vallejo, Fairfield - CA"
-2013,47020,Victoria - TX
-2013,47220,"Vineland, Millville, Bridgeton - NJ"
-2013,47260,"Virginia Beach, Norfolk, Newport News - VA, NC"
-2013,47300,"Visalia, Porterville - CA"
-2013,47380,Waco - TX
-2013,47580,Warner Robins - GA
-2013,47644,"Warren, Troy, Farmington Hills - MI"
-2013,47894,"Washington, Arlington, Alexandria - DC, VA, MD, WV"
-2013,47940,"Waterloo, Cedar Falls - IA"
-2013,48140,Wausau - WI
-2013,48300,"Wenatchee, East Wenatchee - WA"
-2013,48424,"West Palm Beach, Boca Raton, Boynton Beach - FL"
-2013,48540,"Wheeling - WV, OH"
-2013,48620,Wichita - KS
-2013,48660,Wichita Falls - TX
-2013,48700,Williamsport - PA
-2013,48864,"Wilmington - DE, MD, NJ"
-2013,48900,Wilmington - NC
-2013,49020,"Winchester - VA, WV"
-2013,49180,"Winston, Salem - NC"
-2013,49340,Worcester - MA
-2013,49420,Yakima - WA
-2013,49500,Yauco - PR
-2013,49620,"York, Hanover - PA"
-2013,49660,"Youngstown, Warren, Boardman - OH, PA"
-2013,49700,Yuba City - CA
 2013,49740,Yuma - AZ
+2007,99999,NA (Outside of MSA/MD)
+2008,99999,NA (Outside of MSA/MD)
+2009,99999,NA (Outside of MSA/MD)
+2010,99999,NA (Outside of MSA/MD)
+2011,99999,NA (Outside of MSA/MD)
+2012,99999,NA (Outside of MSA/MD)
 2013,99999,NA (Outside of MSA/MD)

--- a/resources/datasets/hmda/generate_msamd_csv.sh
+++ b/resources/datasets/hmda/generate_msamd_csv.sh
@@ -1,0 +1,192 @@
+#! /bin/bash
+#
+# Background:
+# This script can be used to import an XLSX or CSV file that contains MSA codes
+# and names. These fields will be pulled out and placed into a CSV formatted
+# file appropriate for appending to code_sheets/msamd.csv.
+#
+# The expected input format:
+#     code column: MSA code (e.g. 47894)
+#     name_column: MSA name (e.g. "WASHINGTON-ARLINGTON-ALEXANDRIA, DC-VA-MD-WV")
+#
+# The output format:
+#     year_column: (optional)
+#     code column: MSA code (e.g. 47894)
+#     name_column: pretty MSA name (e.g. "Washington, Arlington, Alexandria - DC, VA, MD, WV")
+#
+# Requirements:
+#     xlsx2csv (pip install xlsx2csv) required if using an xlsx file
+#     sed (Mac users: install a newer version of sed: `brew install gnu-sed`)
+#
+
+CSV_APPEND_FILE=
+CODE_COLUMN=1
+NAME_COLUMN=2
+INPUT_TYPE=csv
+PREPEND_YEAR=
+
+OPTIONS_GUIDE="Usage: convert-msalsx-to-html.sh [-c code-column] [-n name-column] [-a csv-append-file] [-t input-type] [-y year] input-file
+    -c	Default: $CODE_COLUMN
+    -n	Default: $NAME_COLUMN
+    -a	Append results to provided filename
+    -t  Options: csv, xlsx	Default: $INPUT_TYPE
+    -y  Prepend year as first column of csv
+"
+
+# Pull out the command line arguments (if any)
+while getopts ":c:n:a:t:y:h" opt; do
+    case $opt in
+        c)
+            CODE_COLUMN=$OPTARG
+            ;;
+        n)
+            NAME_COLUMN=$OPTARG
+            ;;
+        a)
+            CSV_APPEND_FILE=$OPTARG
+            ;;
+        t)
+            case "$OPTARG" in
+                csv|xlsx)
+                    INPUT_TYPE=$OPTARG
+                    ;;
+                *)
+                    echo "Invalid file type specified" >&2
+                    echo "$OPTIONS_GUIDE" >&2
+                    echo 1
+                    ;;
+            esac
+            ;;
+        y)
+            PREPEND_YEAR=$OPTARG
+            ;;
+        h)
+            echo "$OPTIONS_GUIDE" >&2
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            echo "$OPTIONS_GUIDE" >&2
+            exit 1
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))  #This tells getopts to move on to the next argument.
+
+if [ $# -ne 1 ]; then
+     echo "Please include the input file"
+     echo "$OPTIONS_GUIDE" >&2
+     exit 1
+fi
+
+if [[ -n "$CSV_APPEND_FILE" && -z "$PREPEND_YEAR" ]] ; then
+    echo "If appending to an existing CSV file, please define the year"
+    exit 1
+fi
+
+echo $INPUT_TYPE
+if [ $INPUT_TYPE = 'xlsx' ]; then
+    # Use xlsx2csv to convert the xlsx file: https://github.com/dilshod/xlsx2csv
+    # If xlsx2csv is not installed, exit
+    command -v xlsx2csv 2> /dev/null || {
+        echo >&2 "'xlsx2csv' is required for this script to execute. To install, run:
+pip install xlsx2csv 
+Note that root access may be required to run pip commands. Aborting.";
+        exit 1;
+    }
+fi
+
+# NOTE - if using OSX, you'll need to install a newer version of sed to support these queries.
+# `brew install gnu-sed` will create the gsed executable
+sed_bin='sed'
+command -v gsed 2> /dev/null && {
+  sed_bin='gsed'
+}
+
+sed_tweaks='
+  # sed input format       47894,"WASHINGTON-ARLINGTON-ALEXANDRIA, DC-VA-MD-WV",
+  # sed output format      47894,"Washington, Arlington, Alexandria - DC, VA, MD, WV"
+  # Note: also works if | is the delimiter
+
+  # remove any line that does not contain a 5 character integer (MSA code)
+  # i.e. remove any header rows
+  /[0-9]\{5\}[,|]/!d;
+
+  # remove the delimiter (| or ,) at the end of every line
+  s/[,|]$//;
+
+  # replace comma separating city block and state block
+  s/, / - /;
+
+  # replace hyphens between citys with comma and a space
+  # also match -- and / as separators to be more flexible
+  s/\([A-Z]\)\(-\|--\|\/\)\([A-Z]\)/\1, \3/g;
+
+  # remove "CBSA" from MSA codes, if present
+  s/CBSA\([0-9]\{5\}\)/\1/;
+
+  # lowercase words (2+ chars), but keep the first letter capitalized
+  s/\b\([[:alpha:]]\)\([[:alpha:]]\+\)\b/\u\1\L\2/g;
+
+  # uppercase any words that follow " - ", as those are state abbreviations
+  s/\( \- \(\(, \)\?[A-Z][a-z]\)\+\)/\U\1/;
+
+  # special case - uppercase the abbreviations in MSA #99999
+  s/Na (Outside Of Msa, Md)/NA (Outside Of MSA\/MD)/;
+
+  # Remove MSA 00000, if present
+  /00000[,|]/d;
+
+  # remove quotes from lines without commas
+  s/"\([^,]\+\)"/\1/;
+'
+
+if [ $INPUT_TYPE = 'xlsx' ]; then
+    # xlsx2csv gracefully handles unicode nastiness, thankfully.
+    dump_cmd="xlsx2csv -d '|' \"$1\""
+else
+    # To make the output match xlsx2csv...
+    # replace only the first comma with a |
+    # remove any quotes and end-of-line commas
+    dump_cmd="cat \"$1\" | $sed_bin 's/,/|/' | $sed_bin 's/,$//' | tr -d '\"'"
+fi
+
+OUTPUT_REDIRECT="cat"
+if [ -n "$CSV_APPEND_FILE" ]; then
+    OUTPUT_REDIRECT="cat >> $CSV_APPEND_FILE"
+
+    # prep the CSV_APPEND_FILE if it already exists
+    if [ -e "$CSV_APPEND_FILE" ]; then
+        # Backup existing CSV_APPEND_FILE
+        now=`date +"%Y%m%d_%H%M%S"`
+        cp $CSV_APPEND_FILE $CSV_APPEND_FILE.$now
+
+        # Clean out all existing records for the year in CSV_APPEND_FILE
+        $sed_bin -i '/'$PREPEND_YEAR'/d' $CSV_APPEND_FILE
+    fi
+fi
+
+# main procedure:
+# 1 - Dump the input file as a pipe (|) delimited CSV.  Since there are commas
+#     in some msa names, this makes it easier for us to have selectable columns
+#     for code and name.
+# 2 - Output a two column normal CSV (code and name) where name is quoted
+# 3 - Optionally add the year as a third column before the other two
+# 4 - Output to stdout or optionally append to the specified file
+eval \
+    $dump_cmd | \
+    awk -F '|' '{print $'$CODE_COLUMN'",\""$'$NAME_COLUMN'"\""}' | \
+    $sed_bin "$sed_tweaks" | \
+    awk '{if ("'$PREPEND_YEAR'") printf "'$PREPEND_YEAR',"; print $0}' | \
+    eval $OUTPUT_REDIRECT
+
+
+if [ -n "$CSV_APPEND_FILE" ]; then
+    # integrate the new records in CSV_APPEND_FILE
+    # sort alphabetically be MSA code then year
+    sort -n --field-separator=',' -k2 -k1 $CSV_APPEND_FILE -o $CSV_APPEND_FILE
+
+    # if you have issues running the command above, your version of
+    # sort may prefer this syntax for ordering: --key=2,1
+fi


### PR DESCRIPTION
2013 records have been added to the msasm.csv file, and the file was re-sorted using the following command:

```shell
sort -n --field-separator=',' -k2 -k1 msamd.csv
```

Also included is a script to ingest data from a CSV or XLSX in the correct format for the msamd.csv file.  For example, to add 2014 records:

```shell
# output the content to stdout for validation
./generate_msamd_csv.sh -y 2014 input-file.csv

# backup the original end file and apply new records
./generate_msamd_csh.sh -y 2014 -a code_sheets/msamd.csv input-file.csv
```

TODO: The script does not handle a couple edge cases with upper/lowercasing:
- Some non-standard letters may not be the correct case
- Some 2 letter words may not have the correct case
  - e.g. with this script `Fond du Lac` would be `Fond Du Lac`