### PR TITLE
Add N/A value to "Consumer disputed?" field notes

### DIFF
--- a/ccdb/fields.html
+++ b/ccdb/fields.html
@@ -155,9 +155,11 @@ nav: fields
 			<td data-label="Description">Whether the consumer disputed the company’s response</td>
 			<td data-label="Data type">plain text</td>
 			<td data-label="Notes">
-				<strong>yes</strong>
+				<strong>Yes</strong>
 				<br/>
-				<strong>no</strong>
+				<br/>
+				<strong>No</strong>
+				<br/>
 				<br/>
 				<strong>N/A:</strong> The Bureau discontinued the consumer dispute option on April 24, 2017.
 			</td>

--- a/ccdb/fields.html
+++ b/ccdb/fields.html
@@ -154,7 +154,13 @@ nav: fields
 			<td data-label="Field name">Consumer disputed?</td>
 			<td data-label="Description">Whether the consumer disputed the company’s response</td>
 			<td data-label="Data type">plain text</td>
-			<td data-label="Notes">yes/no</td>
+			<td data-label="Notes">
+				<strong>yes</strong>
+				<br/>
+				<strong>no</strong>
+				<br/>
+				<strong>N/A:</strong> The Bureau discontinued the consumer dispute option on April 24, 2017.
+			</td>
 		</tr>
 		<tr>
 			<td data-label="Field name">Complaint ID</td>


### PR DESCRIPTION
This PR modifies the "Consumer disputed?" field per stakeholder request in GHE/CFGOV/platform/issues/906 to include a "N/A" value with a description of that value.

Preview the change here: https://willbarton.github.io/api/ccdb/fields.html