### PR TITLE
CCDB5 api docs moved from master to main branch names

### DIFF
--- a/ccdb/api/index.html
+++ b/ccdb/api/index.html
@@ -77,7 +77,7 @@ window.onload = function() {
   
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "https://raw.githubusercontent.com/cfpb/ccdb5-api/master/swagger-config.yaml",
+    url: "https://raw.githubusercontent.com/cfpb/ccdb5-api/main/swagger-config.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
Updated CCDB5-API primary branch to `main`. Requires a documentation update to point to the correct source.