### PR TITLE
Fix the Swagger docs to reflect the API change for`hits.total`

### DIFF
--- a/ccdb/api/swagger-config.yaml
+++ b/ccdb/api/swagger-config.yaml
@@ -273,7 +273,7 @@ definitions:
             value:
               type: integer
               description: "The count of matching hits, accurate in our code even above 10,000 hits"
-            relation: 
+            relation:
               type: string
               description: "Indicates the accuracy of the default ES response, whether the value is accurate (eq) or a lower bound (gte)"
   Meta:

--- a/ccdb/api/swagger-config.yaml
+++ b/ccdb/api/swagger-config.yaml
@@ -268,8 +268,14 @@ definitions:
         description: "The highest score in the results"
         format: float
       total:
-        type: integer
-        description: "The totol number of complaints that matched the query"
+        type: object
+          parameters:
+            value:
+              type: integer
+              description: "The count of matching hits, accurate in our code even above 10,000 hits"
+            relation: 
+              type: string
+              description: "Indicates the accuracy of the default ES response, whether the value is accurate (eq) or a lower bound (gte)"
   Meta:
     type: object
     parameters:


### PR DESCRIPTION
Our Elasticsearch 7 upgrade changed our API to match the ES API, but we didn't
update the Swagger dogs, in particular the change in what is returned for `hits.total`.

Resolves ccdb5-api issue [179](https://github.com/cfpb/ccdb5-api/issues/179)