### PR TITLE
Release note - Aug 2026, json removal

### DIFF
--- a/ccdb/release-notes.md
+++ b/ccdb/release-notes.md
@@ -10,6 +10,28 @@ nav: release-notes
         <div class="expandable expandable__padded">
             <button class="expandable_header expandable_target" title="Expand content">
                 <span class="expandable_header-left expandable_label">
+                    Release 24 – August 2026
+                </span>
+                <span class="expandable_header-right expandable_link">
+                    <span class="expandable_cue-open">
+                        <span class="u-visually-hidden">Show</span>
+                        <span class="cf-icon cf-icon-plus-round"></span>
+                    </span>
+                    <span class="expandable_cue-close">
+                        Hide
+                        <span class="cf-icon cf-icon-minus-round"></span>
+                    </span>
+                </span>
+            </button>
+            <div class="expandable_content">
+                <p>
+                    To provide a more reliable and consistent experience, filtered exports are limited to 100,000 complaints in CSV format. The JSON option has been retired. Adjust your filters to include 100,000 or fewer complaints to export filtered data or download the entire dataset. 
+                </p>
+            </div>
+        </div>
+        <div class="expandable expandable__padded">
+            <button class="expandable_header expandable_target" title="Expand content">
+                <span class="expandable_header-left expandable_label">
                     Release 23 – July 2026
                 </span>
                 <span class="expandable_header-right expandable_link">


### PR DESCRIPTION
adding note about JSON removal

**Release 24 – August 2026**

To provide a more reliable and consistent experience, filtered exports are limited to 100,000 complaints in CSV format. The JSON option has been retired. Adjust your filters to include 100,000 or fewer complaints to export filtered data or download the entire dataset. 
